### PR TITLE
feat : 3부 완성

### DIFF
--- a/tutorial/startbasic/3bu.py
+++ b/tutorial/startbasic/3bu.py
@@ -1,0 +1,128 @@
+# =============================================================================
+# 파트 3: 챗봇에 메모리 추가 (MemorySaver)
+# =============================================================================
+from dotenv import load_dotenv
+import os
+
+from typing import Annotated
+from typing_extensions import TypedDict
+
+from langchain_openai import ChatOpenAI
+from langchain_tavily import TavilySearch
+from langchain_core.runnables.graph_ascii import draw_ascii
+
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.message import add_messages
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.prebuilt import ToolNode, tools_condition
+
+# =============================================================================
+# 1) 환경변수 로드
+# =============================================================================
+load_dotenv()
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+TAVILY_API_KEY = os.getenv("TAVILY_API_KEY")
+
+# =============================================================================
+# 2) 메모리 및 상태 정의
+#    - MemorySaver: 메모리 내 체크포인트
+#    - State: 대화 메시지를 누적
+# =============================================================================
+# 매번 스크립트 실행할 때 새 인스턴스 생성 -> 프로그램 종료와 함께 초기화
+## 영속성 메모리 필요할때 영속 스토리지를 백엔드로 사용하는 체크포인터를 사용해야 함
+## SqliteSave or PostgresSaver
+memory = MemorySaver()
+
+class State(TypedDict):
+    messages: Annotated[list, add_messages]
+
+# =============================================================================
+# 3) LLM 및 도구 초기화
+# =============================================================================
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0.7)
+search_tool = TavilySearch(max_results=2)
+tools = [search_tool]
+# LLM에 도구 바인딩
+llm_with_tools = llm.bind_tools(tools)
+
+# =============================================================================
+# 4) 그래프 빌드
+#    - chatbot 노드: 사용자 메시지를 LLM에 전달
+#    - tools 노드: ToolNode 사용
+#    - 조건부 분기: tools_condition
+# =============================================================================
+builder = StateGraph(State)
+
+# 4.1) 챗봇 노드 등록
+def chatbot_node(state: State) -> dict:
+    response = llm_with_tools.invoke(state.get("messages", []))
+    return {"messages": [response]}
+builder.add_node("chatbot", chatbot_node)
+
+# 4.2) 도구 노드 등록 (prebuilt ToolNode)
+## ToolNode : LLM이 tool_calls 속성을 담은 AIMessage 반환 시 ToolNode가 메시지를 읽어 각 호출 지시에 맞춰 실제 도구 실행
+## 결과를 ToolMessage 형태로 포장해서 state["messages"]에 돌려줌
+tool_node = ToolNode(tools=tools)
+builder.add_node("tools", tool_node)
+
+# 4.3) 조건부 분기 설정
+builder.add_conditional_edges(
+    "chatbot",
+    tools_condition, # chatbot 노드가 반환한 state 안의 마지막 메시지에 tool_calls가 존재하면 tools 없으면 END
+    {"tools": "tools", END: END}
+)
+
+# 4.4) 엣지 연결: START→chatbot, tools→chatbot
+builder.add_edge(START, "chatbot")
+builder.add_edge("tools", "chatbot")
+
+# 그래프 컴파일 (MemorySaver 체크포인터 포함)
+graph = builder.compile(checkpointer=memory)
+
+# =============================================================================
+# 5) 그래프 구조 시각화
+# =============================================================================
+internal = graph.get_graph()
+vertices = {n: str(n) for n in internal.nodes}
+edges = internal.edges
+print("=== Graph Structure ===")
+print(draw_ascii(vertices, edges))
+
+# =============================================================================
+# 6) 메모리 테스트: 멀티턴 대화 예시
+# =============================================================================
+# Thread '1'에서 첫 입력
+config1 = {"configurable": {"thread_id": "1"}}
+events = graph.stream(
+    {"messages": [{"role": "user", "content": "Hi there! My name is Will."}]},
+    config1,
+    stream_mode="values",
+)
+for evt in events:
+    evt["messages"][-1].pretty_print()
+
+# 같은 Thread에서 두 번째 입력: 사용자 이름 기억 여부 확인
+events = graph.stream(
+    {"messages": [{"role": "user", "content": "Remember my name?"}]},
+    config1,
+    stream_mode="values",
+)
+for evt in events:
+    evt["messages"][-1].pretty_print()
+
+# Thread '2'에서는 메모리가 초기화됨 (다른 Thread)
+config2 = {"configurable": {"thread_id": "2"}}
+events = graph.stream(
+    {"messages": [{"role": "user", "content": "Remember my name?"}]},
+    config2,
+    stream_mode="values",
+)
+for evt in events:
+    evt["messages"][-1].pretty_print()
+
+# =============================================================================
+# 7) 체크포인트 상태 확인
+# =============================================================================
+snapshot = graph.get_state(config1)
+print("[Snapshot]", snapshot)
+print("[Next Node]", snapshot.next)


### PR DESCRIPTION
# 3부 : 챗봇에 메모리 추가

- 이전 상호작용의 맥락을 기억하지 못하여 일관성 있고 여러 차례 대화가 이어지는 대화 제한됨
- LangGraph는  `checkpointer` 그래프를 컴파일때 제공하여 문제 해결
- 그래프를 컴파일할때 `checkpointer=memory` 옵션을 주면 LangGraph가 **각 노드 실행 후 상태를 자동 저장**
- 그래프 호출 시 동일한 `thread_id`를 넘기면 LangGraph가 이전 저장된 상태를 로드하여 대화를 이어감
  - 다른 `thread_id` 를 사용하면 독립적인 대화 세션이 생성됨
- `MemorySaver()`는 튜토리얼용 휘발성 체크포인터(메모리 내 저장)
  - 실제 서비스에는 `SqliteSaver`, `PostgresSaver` 등 영속 스토리지 사용하는 체크포인터 교체 가능

-------------------

# ToolNode

- LLM의 tool_calls를 실제 도구 호출로 연결해주는 노드

## 역할

- `tool_calls` 속성을 담은 `AIMessage` 반환 
- `ToolNode` 가 메시지를 읽어 (AIMessage.tool_calls 리스트)
- 각 호출 지시(name, args)에 맞춰 실제 도구(예시에선 TavilySearch)를 실행(invoke) 하고
- 결과를 `ToolMessage` 형태로 포장해서 `state["messages"]` 에 돌려줌

## 2부에서 어떤것?

```python
# 4.2) 도구 실행 노드: AIMessage 내 tool_calls 처리
class BasicToolNode:
    # 생성자(self는 생성된 인스턴스 자신으로 객체의 속성을 설정할 때 사용합니다.
    def __init__(self, tools: list) -> None:
        self.tools_by_name = {tool.name: tool for tool in tools}

    # 클래스 내부에서 정의된 메서드는 호출 시 self를 자동으로 전달합니다.
    # 클래스 변수 : 클래스 정의 블록 내 직접 할당한 변수 / 인스턴스 변수 : self를 통해 할당된 변수로 인스턴스별 고유 데이터 저장
    # __call__ 메서드 : 파이썬 인터프리터가 인스턴스를 함수 호출하듯 사용할 수 있도록 해줌
    def __call__(self, inputs: dict):
        if messages := inputs.get("messages", []):
            message = messages[-1]
        else:
            raise ValueError("No message found in input")
        outputs = []
        for tool_call in message.tool_calls:
            tool_result = self.tools_by_name[tool_call["name"]].invoke(
                tool_call["args"]
            )
            outputs.append(
                ToolMessage(
                    # 파이썬 객체 -> json으로 직렬화
                    content=json.dumps(tool_result),
                    name=tool_call["name"],
                    tool_call_id=tool_call["id"],
                )
            )
        return {"messages": outputs}

tool_node = BasicToolNode(tools)
# 노드가 실행될 때 tool_node(state) 형태 호출 -> __call__ 메서드 자동 실행됨
graph_builder.add_node("tools", tool_node)
```

- ToolNode의 생성자로 넘긴 tool : BasicToolNode의 생성자로 사용됨
- ToolNode의 실행 결과 상태에 넣는 부분
```python
        for tool_call in message.tool_calls:
            tool_result = self.tools_by_name[tool_call["name"]].invoke(
                tool_call["args"]
            )
            outputs.append(
                ToolMessage(
                    # 파이썬 객체 -> json으로 직렬화
                    content=json.dumps(tool_result),
                    name=tool_call["name"],
                    tool_call_id=tool_call["id"],
                )
            )
        return {"messages": outputs}
```

---------------

# tools_condition

- tool_calls 유무를 보고 "tools" <-> `End` 로 분기해 주는 분기 함수

## 역할

- `add_conditional_edges("chatbot", tools_condition, {...})` 에 넘겨지는 분기 함수
- `chatbot` 노드가 반환한 `state` 안의 마지막 메시지에 `tool_calls`가 존재하면 `tools`로
- 없으면 `END` 로 분기하도록 미리 구현

## 2부에서 어떤것?

```python
# 4.3) 조건부 라우팅: chatbot 이후 도구 호출 여부에 따라 분기
def route_tools(state: State) -> str:
    last = state.get("messages", [])[-1]
    # tool_calls가 있으면 도구 노드로, 없으면 종료
    return "tools" if getattr(last, "tool_calls", None) else END

graph_builder.add_conditional_edges("chatbot", route_tools, {"tools": "tools", END: END})
```

- 2부에서 route_tools 함수 정의한 것을 라이브러리로 제공
  - `tools_condition`

### 3부 사용
```python
# 4.3) 조건부 분기 설정
builder.add_conditional_edges(
    "chatbot",
    tools_condition, # chatbot 노드가 반환한 state 안의 마지막 메시지에 tool_calls가 존재하면 tools 없으면 END
    {"tools": "tools", END: END}
)
```

-------------

# MemorySaver 생성 시점과 지속성

- 현재 예제에서 매번 스크립트 실행 시 `memory = MemorySaver()`로 새 인스턴스 생성
  - 프로그램 재시작하면 그간 저장된 모든 체크포인트(메모리)는 사라짐
  - 메모리는 메모리 내(프로세스 내) 한시적 유지, 프로그램 종료와 함께 초기화 됨

## 영속적 메모리 필요할 때
- **SqliterSaver, PostgresSaver** 같은 영속 스토리지 백엔드 사용하는 체크포인터 사용
```python
from langgraph.checkpoint.sql import SqliteSaver
memory = SqliteSaver(db_path="memory.db")
```
- 다음에 스크립트 재시작해도 해당 `thread_id` 호출하면 이전 상태 복원됨

---------------------------

# LLM이 도구 호출 결정 & 실행

- 개발자가 사용할 도구를 LLM에 등록
- LLM은 대화 맥락을 바탕으로 내부 판단을 통해 답변 자체 생성 or 도구 호출 중 하나를 선택
- 도구 호출이 필요하다고 판단되면 LLM은 응답 메시지에 `tool_calls(또는 OpenAI API 기준 function_call)` 필드를 포함해 "이 도구를 이런 인자로 호출해 달라" 고 JSON 형태로 반환
- 사용자(또는 시스템) 코드는 해당 JSON을 파싱해 실제 도구를 실행
- 그 결과를 `ToolMessage`로 포장하여 대화 히스토리에 다시 추가
- 마지막으로 LLM은 이 도구 실행 결과를 읽고 최종 답변 생성 

## TavilySearch 예시
- tool_calls를 해당 노드에서 있는지 확인하고 도구를 실행
![image](https://github.com/user-attachments/assets/025c90aa-57d7-44da-b78d-94af65dd31ab)
  - 도구 설정에서 결과 2개까지 얻어오게 설정

```json
{
  "query" : "통닭 천사 별명 유래",
  "follow_up_questions" : null,
  "answer" : null,
  "images" : [ ],
  "results" : [ {
    "url" : "https://chimhaha.net/chicken/141682",
    "title" : "통닭천사님 닉네임의 유래는 무엇인가요? - 빵굽는마을(통닭천사)",
    "content" : "통닭천사님 닉네임의 유래는 무엇인가요? ... 문득 궁금한데 웹에 검색해도 잘 안 나와서요… 침하하 횐님들께 여쭙습니다. 혹시 아시는 분은 알려주시면 감사하겠습니다!!!",
    "score" : 0.98548,
    "raw_content" : null
  }, {
    "url" : "https://namu.wiki/w/%ED%86%B5%EB%8B%AD%EC%B2%9C%EC%82%AC?uuid=1b83f7f3-f79f-4a94-abb8-7fecffdfedee",
    "title" : "통닭천사 (r236 판) - 나무위키:대문",
    "content" : "별명[편집]. 통천형, 통형 : 시청자들에게 본인의 닉네임인 통닭천사를 줄여서 '통천'이라고 불리는데 하는 행동이나 입담이나 엄청 털털해서 '형'이라고도 자주 불린다.",
    "score" : 0.98296,
    "raw_content" : null
  } ],
  "response_time" : 2.28
}
```
- **Tool Message 생성하여 messages 상태에 추가**
- **"tools" -> "chatbot"으로 다시 노드 이동**
  - **chatbot 노드에서는 전체 "messages" 를 추출해서 invoke (ToolMessage 포함)**
  ```python
  messages = [
    HumanMessage(...),        # 사용자의 질문
    AIMessage(..., tool_calls=[...]),  # 도구 호출 지시
    ToolMessage(content=tool_result, ...)  # 실제 도구 실행 결과
  ]
  # ↓ 이 messages 전체를 다시 LLM에 넘겨서
  final_response = llm.invoke(messages)
  ```
  - LLM이 도구 실행 결과 맥락으로 최종 답변을 자동으로 만들어줌

