### PR TITLE
feat : 4부 완성

### DIFF
--- a/tutorial/startbasic/4bu.py
+++ b/tutorial/startbasic/4bu.py
@@ -1,0 +1,150 @@
+# =============================================================================
+# 4부: 인간 참여(Human-in-the-Loop) 예제 전체 코드
+# =============================================================================
+# 1) 기본 라이브러리 및 환경 변수 로드
+from dotenv import load_dotenv        # .env 파일에서 API 키를 로드
+import os                             # 환경 변수 접근용
+
+# 메시지 타입, 도구, 체크포인터, 그래프 모듈
+from typing import Annotated
+from typing_extensions import TypedDict
+from langchain_openai import ChatOpenAI
+from langchain_tavily import TavilySearch
+from langchain_core.tools import tool
+from langchain_core.runnables.graph_ascii import draw_ascii
+
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.message import add_messages
+from langgraph.prebuilt import ToolNode, tools_condition
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.types import Command, interrupt
+
+# =============================================================================
+# 1) 환경변수 로드
+# =============================================================================
+load_dotenv()
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+TAVILY_API_KEY = os.getenv("TAVILY_API_KEY")
+
+# =============================================================================
+# 2) 상태(State) 타입 정의
+# =============================================================================
+class State(TypedDict):
+    # 대화 히스토리를 누적하는 리스트
+    messages: Annotated[list, add_messages]
+
+# =============================================================================
+# 3) 그래프 빌더 생성
+# =============================================================================
+builder = StateGraph(State)
+
+# =============================================================================
+# 4) 인간 지원 도구 정의 (@tool + interrupt)
+# =============================================================================
+@tool
+def human_assistance(query: str) -> str:
+    """
+    - 이 도구는 사람의 승인이 필요할 때 사용됩니다.
+    - interrupt() 호출 시 그래프가 중단되고, 외부에서 입력된 답변을 기다립니다.
+    """
+    # 그래프 실행 일시 중지 및 외부 입력 대기
+    result = interrupt({"query": query})
+    # 사용자(사람)가 제공한 'data' 필드를 반환
+    return result["data"]
+
+# =============================================================================
+# 5) LLM 및 외부 도구 초기화
+# =============================================================================
+# 웹 검색용 도구 (TavilySearch)
+search_tool = TavilySearch(max_results=2)
+# 인간 지원 도구 포함
+tools = [search_tool, human_assistance]
+# ChatOpenAI 모델 초기화
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0.7)
+# 도구를 LLM에 바인딩하여 tool_calls 기능 활성화
+llm_with_tools = llm.bind_tools(tools)
+
+# =============================================================================
+# 6) 챗봇 노드 정의 및 등록
+# =============================================================================
+def chatbot_node(state: State) -> dict:
+    """
+    - State.messages 전체를 LLM에 전달합니다.
+    - LLM이 tool_calls를 포함한 AIMessage를 반환할 수 있습니다.
+    """
+    msg = llm_with_tools.invoke(state.get("messages", []))
+    # 중단점 도입 시 중복 호출 방지를 위해 tool_calls 최대 1개 제한
+    assert len(msg.tool_calls) <= 1
+    return {"messages": [msg]}
+
+builder.add_node("chatbot", chatbot_node)
+
+# =============================================================================
+# 7) 도구 실행 노드 등록 (ToolNode)
+# =============================================================================
+tool_node = ToolNode(tools=tools)
+builder.add_node("tools", tool_node)
+
+# =============================================================================
+# 8) 분기 설정: tool_calls 유무에 따라 tools 또는 종료로 이동
+# =============================================================================
+builder.add_conditional_edges(
+    "chatbot",
+    tools_condition,    # 마지막 AIMessage에 tool_calls가 있으면 "tools" 아니면 END
+    {"tools": "tools", END: END}
+)
+
+# START → chatbot, tools → chatbot 으로 연결
+builder.add_edge(START, "chatbot")
+builder.add_edge("tools", "chatbot")
+
+# =============================================================================
+# 9) 체크포인터 설정 및 그래프 컴파일
+# =============================================================================
+# MemorySaver: 메모리 내 휘발성 체크포인터
+memory = MemorySaver()
+# 그래프 컴파일 시 checkpointer 옵션에 memory 전달
+graph = builder.compile(checkpointer=memory)
+
+# =============================================================================
+# 10) 그래프 구조 시각화
+# =============================================================================
+internal = graph.get_graph()
+vertices = {n: str(n) for n in internal.nodes}
+edges = internal.edges
+print("=== Graph Structure ===")
+print(draw_ascii(vertices, edges))
+
+# =============================================================================
+# 11) 실행 예시: Human-in-the-Loop 워크플로우
+# =============================================================================
+# (1) 사용자 초기 입력
+user_input = "I need some expert guidance for building an AI agent."
+
+# (2) thread_id "1"로 그래프 실행 → human_assistance 호출 지시 후 중단
+config = {"configurable": {"thread_id": "1"}}
+events = graph.stream(
+    {"messages": [{"role": "user", "content": user_input}]},
+    config,
+    stream_mode="values",
+)
+for evt in events:
+    # 도구 호출 지시가 있는 AIMessage 출력
+    evt["messages"][-1].pretty_print()
+
+# (3) 사람이 응답을 제공 → resume 명령 생성
+human_response = (
+    "We, the experts are here to help! "
+    "I recommend checking out LangGraph's docs and examples."
+)
+resume_cmd = Command(resume={"data": human_response})
+
+# (4) resume 명령으로 그래프 재개 → 최종 응답 생성
+events = graph.stream(resume_cmd, config, stream_mode="values")
+for evt in events:
+    evt["messages"][-1].pretty_print()
+
+# (5) 체크포인트 상태 확인
+snapshot = graph.get_state(config)
+print("[Snapshot]:", snapshot)
+print("[Next nodes]:", snapshot.next)  # END에 도달 -> 빈 리스트([])


### PR DESCRIPTION
# 4부 Human-in-the-Loop

- 에이전트가 도구 호출 전 사람의 승인을 받도록 중단점(breakpoint) 설정 패턴
- `@tool` 데코레이터로 정의한 `human_assistance` 함수 안에서 `interrupt(...)`를 호출하여 그래프 실행 일시 중지하고 외부(사람)으로부터 입력을 받은 후 `Command(resume=...)` 형태 다시 실행 재개하는 방식
- 체크 포인터 계층과 결합되어 `thread_id`별로 중단된 상태를 저장했다가 재개하게 할 수 있음

## 전반적 흐름

- 1. 사용자 입력 -> `chatbot` 노드 호출
- 2. `chatbot` 노드 내 LLM 호출 -> AI Message (tool_calls : human_assistance)
  - 응답에서 `tool_calls` 있으니까 `tools 노드`로 이동
- 3. `human_assistance 도구` 내 `interrrupt로 인해 사용자 응답 대기`
- 4. Command에 사용자 응답 생성하고 해당 checkPoint 로 그래프 재시작
  - memorysaver에 저장된 시점 이어서 시작
- 5. tool(`human_assistance 도구` )가 메세지 반환(ToolMessage 형태)
  - graph 설정에 따라 tools -> chatbot 노드 이동 
- 6. (chatbot 노드) ToolMessage 등 이전 기록 모두 LLM에 넣고  invoke -> AIMessage 상태에 추가
  - 응답에 tool_calls 없기에 End로 이동

## interrupt() 함수의 반환값 구조

- `interrupt()` 동작 원리
  - 노드 함수 내부에서 `interrupt(value)` 호출
  - 그래프 엔진이 `GraphInterrupt` 예외를 발생시켜 실행 중단
  - **체크포인터**가 현재 상태와 함께 중단 지점 저장
  - 클라이언트가 `Command(resume=resume_value)`를 사용해 그래프 재호출
  - `interrupt()`는 첫 번째 인자로 전달한 `value` 대신 `resume_value` 반환

- 코드에서 `Command(resume={"data": human_response}) 로 그래프 재호출`
  ```python
  result = interrupt({"query": query})
  return result["data"] # 이렇게 꺼내기 `Command ` resume 속성의 `data`
  ```

- 반환되는 `resume_value` 확인을 위해 디버그 모드 진입

```python
{
  'data': "We, the experts are here to help! I recommend checking out LangGraph's docs and examples."
}
```

- 즉 `interrupt()` 호출은 내부적으로 `resume` 딕셔너리를 그대로 반환한다.
- **`result` 의 형태는 `Command` 생성자에 넣은 그대로인 사전 형태로 키:값을 자유롭게 설계할 수 있음**

## `@tool` 데코레이터 사용 방법

- 함수 위에 `@tool` 사용
  - 도구 이름 : 함수명
  - 설명(description) : 함수의 docstring
  - 파라미터 스키마 : 매개변수 타입 주석으로 자동 생성

- 예시
```python
@tool
# query:str 이 파라미터 스키마로 사용됨
def human_assistance(query: str) -> str:  
    """Request assistance from a human."""  # 설명 
    result = interrupt({"query": query})
    return result["data"]

- `human_assistance.invoke({"query": ...})` 쓰듯 호출 가능

- `human_assistance.args` 혹은 `human_assistance.args_schema.model_json_schema()` 찍으면
```json
{
  "title": "HumanAssistanceSchema",
  "type": "object",
  "properties": {
    "query": {
      "title": "Query",
      "type": "string"
    }
  },
  "required": ["query"]
}
```

## tool_calls에 human_assistance가 항상 포함되는데 왜일까?

### 문장별 한글 번역

- 처음 요청 메세지
> “I need some expert guidance for building an AI agent.”
> “AI 에이전트를 구축하는 데 있어 전문가의 지도가 필요합니다.” 

- 두번째 사용자 응답 메세지
> “We, the experts are here to help! I recommend checking out LangGraph's docs and examples.”
> “저희 전문가가 도와드리기 위해 여기 있습니다! LangGraph의 문서와 예제를 살펴보시길 권장합니다.” 

### 해석에 답이 있다.
- 사용자가 “expert guidance”를 요청했다는 것은, LLM(모델) 스스로 처리하기보다는 사람(전문가)의 의견을 듣고 싶다는 의미로 해석
  - 따라서 LangGraph 예제에서 human_assistance 도구를 호출하도록 설계된 것

## Command로 중단점 재개하는 LangGraph 문법
- 생성자 인자
  - `resume = value` : 마지막 `interrupt`가 반환할 값
  - `update = {..}` : 노드 상태를 갱신할 키, 값
  - `goto = "node_name"` : 재개 후 분기할 노드 지정

```python
from langgraph.types import Command

# 단순 재개
cmd = Command(resume={"data": human_response})

# 상태 업데이트 + 다른 노드로 이동
cmd2 = Command(update={"foo":"bar"}, goto="next_node")
```

### 위 예시에서 cmd를 활용할 시
- graph.stream(cmd, config) 또는 graph.invoke(cmd, config)에 넘기면, 저장된 체크포인트 위치부터 노드가 다시 실행
- 첫 번째 interrupt() 호출은 value를 반환하고 다음 로직을 이어갑니다

### 위 예시에서 cmd2를 활용할 시
```python
result = interrupt({"query": query})
return result["data"] # 이렇게 꺼내기 `Command ` resume 속성의 `data`
```

- `interrupt()` 지점에서 **resume** 페이로드 반환하지 않고 **상태 업데이트** 와 **강제 분기** 정보만 Graph 엔진에 전달

### cmd2 활용 흐름

- 1. `result = interrupt(...)` 호출 지점
  - 1차 실행에서는 `GraphInterrupt` 예외 발생해 함수 실행 멈춤
- 2. `Command(update={"foo":"bar"}, goto="next_node")` 로 재개
  - Graph는 지정된 체크포인트 위치로 돌아가 노드를 **재실행**
  - 첫 번째 `interrupt()`는 `resume` 대신 `update` / `goto` 정보를 적용
    - `state["foo"] = "bar"` 상태 반영
    - 다음 실행 노드 `next_node` 로 즉시 변경
  -** 이 과정에서 `return result["data"]` 라인을 건너뛰고, 도구 호출 결과(`ToolMessage`)도 생성하지 않음**

## get_state 함수

- 저장된 전체 Graph 상태를 반환하는 객체
  - snapshot.config : 사용된 thread_id 등
  - snapshot.next : 다음 실행될 노드 이름 리스트
- snapshot.next가 비어 있으면, 그래프는 이미 END에 도달한 상태

## graph invoke / stream 매개변수 구성

### graph.stream(inputs, config, stream_mode)

- inpuits : `{"messages": [...]} 또는 Command 객체`
- config : `{"configurable" : {"thread_id":...}}`
- stream_mode : "value", "messages", ...

### invoke(inputs, config)
- 스트리밍 없이 한 번에 최종 결과만 반환
- 중단점 재개 시에도 사용할 수 있음

## AI Agent 개발이란?
- LangGraph 등 프레임워크를 활용해 **LLM + 도구 + 메모리 + 제어 흐름** 을 결합한 프로그램을 만드는 것
- 단순 LLM 프롬프트 뿐만 아닌
  - 노드 (작업 단위)
  - 엣지 (흐름 제어)
  - 체크포인터 (메모리)
  - 인터럽트 (휴먼 개입)
  - 툴 호출 (외부 함수/서비스)
등 유기적 설계하여 자율적이면서 안전한 AI 워크플로우 구축하는 활동
- 예) 고객지원 자동화, 의약품 컴플라이언스, 복잡한 의사결정 보조 등 다양
