### PR TITLE
feat : 5부 완성

### DIFF
--- a/tutorial/startbasic/5bu.py
+++ b/tutorial/startbasic/5bu.py
@@ -129,6 +129,10 @@ events = graph.stream(
 for evt in events:
     evt["messages"][-1].pretty_print()
 
+snapshot = graph.get_state(config)
+print(">>> SNAPSHOT :", snapshot)
+print(">>> NEXT NODES:", snapshot.next)
+
 # 사용자 응답을 재개하는 Command
 human_command = Command(resume={
     "name": "LangGraph",

--- a/tutorial/startbasic/5bu.py
+++ b/tutorial/startbasic/5bu.py
@@ -1,0 +1,143 @@
+# =============================================================================
+# 1) 환경변수 로드
+#    - .env 파일에서 API 키를 불러와 환경 변수로 설정합니다.
+# =============================================================================
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+TAVILY_API_KEY = os.getenv("TAVILY_API_KEY")
+
+# =============================================================================
+# 2) 상태 타입 정의
+#    - TypedDict로 messages, name, birthday 필드를 정의합니다.
+#    - add_messages 어노테이션으로 메시지 리스트를 자동 병합 처리합니다.
+# =============================================================================
+from typing import Annotated
+from typing_extensions import TypedDict
+from langgraph.graph.message import add_messages
+
+class State(TypedDict):
+    messages: Annotated[list, add_messages]
+    name: str
+    birthday: str
+
+# =============================================================================
+# 3) 도구 정의: human_assistance
+#    - 사용자 검토가 필요한 정보를 인간에게 묻기 위해 중단점(interrupt) 사용
+#    - Command(update)로 상태를 갱신하는 패턴
+# =============================================================================
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import InjectedToolCallId, tool
+from langgraph.types import Command, interrupt
+
+@tool
+def human_assistance(
+    name: str,
+    birthday: str,
+    tool_call_id: Annotated[str, InjectedToolCallId]
+) -> Command:
+    """
+    인간 검토가 필요할 때 사용되는 도구입니다.
+    interrupt() 호출 시 그래프가 멈추고 외부 입력을 기다립니다.
+    """
+    # 그래프 일시 중단: 사용자 응답 대기
+    human_response = interrupt({
+        "question": "Is this correct?",
+        "name": name,
+        "birthday": birthday,
+    })
+
+    # 검토 결과에 따라 상태 결정
+    if human_response.get("correct", "").lower().startswith("y"):
+        verified_name = name
+        verified_birthday = birthday
+        response = "Correct"
+    else:
+        verified_name = human_response.get("name", name)
+        verified_birthday = human_response.get("birthday", birthday)
+        response = f"Made a correction: {human_response}"
+
+    # 상태 업데이트 및 ToolMessage 삽입
+    state_update = {
+        "name": verified_name,
+        "birthday": verified_birthday,
+        "messages": [
+            ToolMessage(response, tool_call_id=tool_call_id)
+        ],
+    }
+    return Command(update=state_update)
+
+# =============================================================================
+# 4) 노드 및 그래프 구성
+#    - ChatOpenAI 모델과 검색/인간 지원 도구를 바인딩
+#    - chatbot 노드, ToolNode, 조건부 분기 설정
+#    - MemorySaver 체크포인터 사용
+# =============================================================================
+from langchain_openai import ChatOpenAI
+from langchain_tavily import TavilySearch
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import StateGraph, START, END
+from langgraph.prebuilt import ToolNode, tools_condition
+
+# 도구 초기화
+search_tool = TavilySearch(max_results=2)
+tools = [search_tool, human_assistance]
+
+# LLM에 도구 바인딩
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0.7)
+llm_with_tools = llm.bind_tools(tools)
+
+# 챗봇 노드 정의
+
+def chatbot(state: State) -> dict:
+    message = llm_with_tools.invoke(state["messages"])
+    assert len(message.tool_calls) <= 1
+    return {"messages": [message]}
+
+# 그래프 빌더 설정
+builder = StateGraph(State)
+builder.add_node("chatbot", chatbot)
+builder.add_node("tools", ToolNode(tools=tools))
+builder.add_conditional_edges("chatbot", tools_condition)
+builder.add_edge(START, "chatbot")
+builder.add_edge("tools", "chatbot")
+
+# 체크포인터 설정 및 컴파일
+t = MemorySaver()
+graph = builder.compile(checkpointer=t)
+
+# =============================================================================
+# 5) 실행 흐름 예시
+#    1) 사용자 질문 → 2) 검색 도구 호출 → 3) 인간 검토 도구 호출 →
+#    4) 사용자 응답 재개 → 5) 최종 상태 확인
+# =============================================================================
+from langgraph.types import Command
+
+user_input = (
+    "Can you look up when LangGraph was released? "
+    "When you have the answer, use the human_assistance tool for review."
+)
+config = {"configurable": {"thread_id": "1"}}
+
+events = graph.stream(
+    {"messages": [{"role": "user", "content": user_input}]},
+    config,
+    stream_mode="values",
+)
+for evt in events:
+    evt["messages"][-1].pretty_print()
+
+# 사용자 응답을 재개하는 Command
+human_command = Command(resume={
+    "name": "LangGraph",
+    "birthday": "Jan 17, 2024",
+})
+events = graph.stream(human_command, config, stream_mode="values")
+for evt in events:
+    evt["messages"][-1].pretty_print()
+
+# 최종 상태 스냅샷 확인
+snapshot = graph.get_state(config)
+print({k: v for k, v in snapshot.values.items() if k in ("name", "birthday")})


### PR DESCRIPTION
# 5부 : Customizing State

## 전반적 흐름 요약

1. 사용자 질문

2. (chatbot 노드) AIMessage 반환
- tool_calls : { name : tavily_search, ... }
- 노드 이후 분기문에 의해 tools 노드 이동

3. (tools 노드) ToolMessage 반환
- {answer : null , ....}
- 노드 이후 다시 chatbot 노드 이동 (그래프 엣지 정의)

4. (chatbot 노드) AIMessage 반환
- 전체 메세지 히스토리를 인자로 LLM 호출
- tool_calls : { name : human_assistance, ... }
- 노드 이후 분기문에 의해 tools 노드 이동

6. (tools 노드) Interrupt 대기
- 사용자 응답 대기
- CheckPoint에 저장됨

7. 사용자 입력 -> Command 객체 생성

8. 6에서 생성한 Command 객체로 그래프 호출 재개

9. 저장된 state 참조하여 tools 노드의 interrupt 지점 이동 -> 해당 변수에 사용자 응답 저장

10.  (tools 노드) human_assistance 도구의 반환에서 새로운 상태 update 지시
- ToolMessage 추가 + 사용자 응답으로 LangGraph 탄생일 업데이트
- 노드 이후 다시 chatbot 노드 이동  (그래프 엣지 정의)
11. (chatbot 노드) LLM에게 message state 전달 및 AIMessage 추가한 상태로 업데이트

## Tavily Search 응답 구조

```json
{
  "query": "LangGraph release date",
  "follow_up_questions": null,
  "answer": null,
  "images": [],
  "results": [
    {
      "title": "Releases · langchain-ai/langgraph - GitHub",
      "url": "https://github.com/langchain-ai/langgraph/releases",
      "excerpt": "Releases · langchain-ai/langgraph GitHub Copilot Write better code with AI GitHub Advanced Security Find and fix vulnerabilities Code Search Find more, search less…",
      "relevance_score": 0.58862966
    },
    {
      "title": "Announcing LangGraph v0.1 & LangGraph Cloud: Running agents at scale, reliably",
      "url": "https://blog.langchain.dev/langgraph-cloud/",
      "excerpt": "Announcing LangGraph v0.1 & LangGraph Cloud: Running agents at scale, reliably… Our new infrastructure for running agents at scale, LangGraph Cloud, is available in beta…",
      "relevance_score": 0.32347676
    }
  ],
  "response_time": 2.0
}

```
- `answer` : 원본 쿼리에 대한 명시적 답변(요약문) 또는 `null`
- `results`
  - `title` : 문서 제목
  - `url` : 문서 URL
  - `content` : 본문 스니펫
  - `raw_content` : 정제 전 HTML (기본 `null`)
- `images`, `fallow_up_questions`, `respomse_time` 등 부과정보

> LLM 판단 기준
> - Tavily Search 도구의 `answer` 가 `null`이면 **도구는 정답을 직접 제공하지 못했다**는 의미. 이는 대부분 LLM이 **다음 행동(예 : 인간 검토)**를 결정하게 됩니다.

## LLM의 도구 호출 결정 기준

- LLM은 **함수 스키마**(`name`, `description`, `parameter`)와 **사용자 질문**을 비교하여 스스로 처리 불가능하거나 신뢰도가 낮다고 판단되는 경우 `tool_calls` 필드를 포함한 `AIMessage`를 생성합니다.
  - ex) LangGraph releeased date 질문 -> `answer = null` -> `human_assistance` 호출 지시

## `interrupt()` 매개변수의 의미

### 내부용 프롬프트 역할
- `interrupt({"question":"Is this correct?","name":…, "birthday":…})`
  - UI에 직접 노출되지 않음: 이 매개변수는 **클라이언트 코드**(예: StreamHandler)가 사람에게 어떤 질문을 보여줄지 결정하기 위해 사용됩니다 
  - 예를 들어, 웹 UI라면 이 question 필드를 기반으로 “Is this correct?” 라는 문구와 함께 name/birthday 폼을 띄울 수 있습니다.
  - 콘솔 앱에서는 단순히 input()을 호출할 때 안내 문구로 사용할 수도 있습니다.

### 인터럽트 후 state 출력
```json
{
  "state": {
    "messages": [
      {
        "role": "human",
        "content": "Can you look up when LangGraph was released? When you have the answer, use the human_assistance tool for review.",
        "id": "0ff36497-65ce-4dfc-ae12-a1959ae3936d"
      },
      {
        "role": "ai",
        "content": "",
        "tool_calls": [
          {
            "name": "tavily_search",
            "args": {"query": "LangGraph release date"},
            "id": "call_BRHKeKp0QS8eMWKm4vMDGVzD",
            "type": "tool_call"
          }
        ],
        "id": "run--0e3333fb-faa5-4816-8f59-d26ea401fd9e-0"
      },
      {
        "role": "tool",
        "content": "{\"query\": \"LangGraph release date\", \"answers\": null, ...}",
        "tool_call_id": "call_BRHKeKp0QS8eMWKm4vMDGVzD"
      },
      {
        "role": "ai",
        "content": "",
        "tool_calls": [
          {
            "name": "human_assistance",
            "args": {"name": "LangGraph", "birthday": "2023-01-01"},
            "id": "call_4nKYTGyqHqgDwH85uMlQZAJq",
            "type": "tool_call"
          }
        ],
        "id": "run--8a85bde2-f64d-4676-8d1a-5f21cf67c923-0"
      }
    ],
    "name": "LangGraph",
    "birthday": "2023-01-01"
  },
  "next": [
    "tools"
  ],
  "config": {
    "configurable": {
      "thread_id": "1",
      "checkpoint_ns": "",
      "checkpoint_id": "1f02a576-9ab5-6bca-8003-46ba9c9551ca"
    }
  },
  "interrupts": [
    {
      "value": {
        "question": "Is this correct?",
        "name": "LangGraph",
        "birthday": "2023-01-01"
      },
      "resumable": true,
      "namespace": [
        "tools:2abb2a29-3208-47c5-f6f6-1975c750eb4d"
      ]
    }
  ]
}
```

- 인터럽트 추출해서 프론트에 뿌려주거나 콘솔에 출력해서 사용자 입력을 받은 뒤 Command로 감싸서 다시 그래프를 호출하든 해야할듯

## 의문점 : 프롬프트 지시 사항과 맞지 않지 않나?

```python
user_input = (
    "Can you look up when LangGraph was released? "
    "When you have the answer, use the human_assistance tool for review."
)
```

- 위 사용자 입력에서, **When you have the answer,  use the human_assistance tool for review.** 부분 
  - 답을 찾으면 human_assistance 도구를 사용하여 검토해 보세요. 란 의미
- 그렇지만 `tavily_search` 결과의 `result`는 null로 나옴
- 그러면 답이 없어서 도구를 추가로 호출 안해야 하는거 아닌가?

### 검색 결과의 answer 필드와 무관

- tavily_search의 응답에서 "answer": null 는 “정확한 요약답변이 없다”는 뜻일 뿐,
- LLM은 “검색 결과(=answer가 null이든 아니든)가 일단 도착했으니 ‘답을 확보했다’”고 본격적인 다음 단계로 넘어갑니다.
- 즉, answer가 null이어도 “검색이 끝났으니” 프롬프트의 지시를 따라 human_assistance를 호출하게 됩니다 .


 