### PR TITLE
feat : 6부 완성

### DIFF
--- a/tutorial/startbasic/6bu.py
+++ b/tutorial/startbasic/6bu.py
@@ -1,0 +1,122 @@
+# =============================================================================
+# 1) 환경변수 로드
+#    - .env 파일에서 API 키를 불러와 환경 변수로 설정합니다.
+# =============================================================================
+from dotenv import load_dotenv
+import os
+
+# .env 파일 읽기
+load_dotenv()
+# OPENAI/MODEL API 키 환경 변수에서 가져오기
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+TAVILY_API_KEY = os.getenv("TAVILY_API_KEY")
+
+# =============================================================================
+# 2) 상태(State) 타입 정의
+#    - TypedDict로 messages 리스트를 정의합니다.
+#    - add_messages 어노테이션으로 메시지들이 자동으로 누적되도록 설정.
+# =============================================================================
+from typing import Annotated
+from typing_extensions import TypedDict
+from langgraph.graph.message import add_messages
+
+class State(TypedDict):
+    # 대화 히스토리를 누적하는 리스트
+    messages: Annotated[list, add_messages]
+
+# =============================================================================
+# 3) 노드 및 도구 초기화
+#    - Chat 모델과 검색 도구를 초기화하고 바인딩합니다.
+# =============================================================================
+from langchain_openai import ChatOpenAI
+from langchain_tavily import TavilySearch
+from langgraph.prebuilt import ToolNode, tools_condition
+
+# 3.1) 검색 도구 생성 (TavilySearch)
+search_tool = TavilySearch(max_results=2)
+# 등록할 도구 리스트
+tools = [search_tool]
+
+# 3.2) ChatOpenAI 모델 초기화 및 도구 바인딩
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0.7)
+llm_with_tools = llm.bind_tools(tools)
+
+# 3.3) chatbot 노드: 대화 히스토리를 받아 LLM 호출 결과를 메시지로 반환
+def chatbot(state: State) -> dict:
+    # state["messages"] 안에 누적된 Human/AI/Tool 메시지를 LLM에 전달
+    reply = llm_with_tools.invoke(state["messages"])
+    return {"messages": [reply]}
+
+# =============================================================================
+# 4) 그래프 빌드
+#    - StateGraph에 노드와 엣지를 정의하고 체크포인터를 설정합니다.
+# =============================================================================
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import StateGraph, START, END
+
+# 4.1) 그래프 빌더 생성
+builder = StateGraph(State)
+# 4.2) 노드 등록: chatbot, tools
+builder.add_node("chatbot", chatbot)
+builder.add_node("tools", ToolNode(tools=tools))
+# 4.3) 분기 설정: chatbot 후 도구 호출 여부에 따라 tools 또는 END
+builder.add_conditional_edges("chatbot", tools_condition)
+# 4.4) 엣지 연결: START→chatbot, tools→chatbot
+builder.add_edge(START, "chatbot")
+builder.add_edge("tools", "chatbot")
+
+# 4.5) 휘발성 메모리 체크포인터 설정
+memory = MemorySaver()
+# 4.6) 그래프 컴파일
+graph = builder.compile(checkpointer=memory)
+
+# =============================================================================
+# 5) 시간여행 예시: 두 차례 대화 후 상태 기록
+#    - get_state_history를 이용해 스냅샷들을 순회
+# =============================================================================
+config = {"configurable": {"thread_id": "1"}}
+
+# 첫 번째 사용자 질문 실행
+events = graph.stream(
+    {"messages": [{"role": "user", "content": "I'm learning LangGraph. Could you do some research on it for me?"}]},
+    config,
+    stream_mode="values"
+)
+for evt in events:
+    evt["messages"][-1].pretty_print()
+
+# 두 번째 사용자 질문 실행
+events = graph.stream(
+    {"messages": [{"role": "user", "content": "Ya that's helpful. Maybe I'll build an autonomous agent with it!"}]},
+    config,
+    stream_mode="values"
+)
+for evt in events:
+    evt["messages"][-1].pretty_print()
+
+# =============================================================================
+# 6) 체크포인트 기록 확인 및 재생할 시점 선택
+#    - get_state_history로 이전 스냅샷을 나열
+#    - 대화 메시지 수로 특정 스냅샷 선택
+# =============================================================================
+
+to_replay = None
+# 전체 히스토리 순회: 각 StateSnapshot 객체
+for snapshot in graph.get_state_history(config):
+    count = len(snapshot.values["messages"])
+    print(f"Num Messages: {count}, Next node: {snapshot.next}")
+    # 예: 메시지 6개일 때 다시 시작하고 싶다면
+    if count == 6:
+        to_replay = snapshot
+
+# 재생할 스냅샷 정보 확인
+print("Replaying from next node:", to_replay.next)
+print("Use config:", to_replay.config)
+
+# =============================================================================
+# 7) 시간여행: 선택한 스냅샷으로 그래프 재실행
+#    - to_replay.config에 담긴 checkpoint_id를 사용
+#    - stream(None, to_replay.config) 으로 과거부터 다시 진행
+# =============================================================================
+for evt in graph.stream(None, to_replay.config, stream_mode="values"):
+    evt["messages"][-1].pretty_print()


### PR DESCRIPTION
# 6부 : 시간여행(Time travel)

- 사용자가 이전 응답에서 시작해 별도 결과를 탐색 or  사용자가 어시스턴트의 작업을 되돌려 오류 수정 or 다른 전략 시도
- 그래프의 메서드를 이용하여 체크 포인트를 가져온 뒤 그래프를 되감는 예제

## `get_state_history` 메서드 상세 설명

- `get_state_history(config, *, before=None, limit=None)`는 주어진 `thread_id`의 **모든 체크포인트 이력을** `StateSnapshot` 객체의 이터레이터로 반환합니다
- 반환된 `StateSnapshot`들은 **시간순(가장 최근이 첫 번째)** 으로 정렬되어 있어, 그래프 실행의 모든 단계별 상태를 순회할 수 있습니다
- 각 `StateSnapshot` 객체는 다음 속성을 가집니다:  
  - `values`: 해당 시점의 **전체 상태(state) 딕셔너리**  
  - `next`: **다음에 실행될 노드**의 이름 튜플  
  - `config`: 해당 체크포인트를 가리키는 `RunnableConfig` (예: `thread_id`, `checkpoint_id`)  
  - `metadata`, `parent_config`: 메타데이터와 부모 체크포인트 정보
- `snapshot.values`는  예를 들어 `{"messages": [...], "foo": ..., "bar": ...}` 와 같이, 그 시점의 모든 사용자·AI·툴 메시지와 커스텀 필드를 포함합니다.
- `snapshot.next`가 `("tools",)`라면, **다음 실행 노드**가 `tools`임을 나타냅니다. 
- `snapshot.config` 내부 `checkpoint_id`는 재생·분기·업데이트에 쓰이는 **핵심 식별자**로, 이 값을 사용해 과거 상태로 정확히 되돌아갈 수 있습니다.
- `before` 파라미터로 특정 시점 이전의 이력만 필터링하거나, `limit`으로 반환 개수를 제한할 수도 있습니다. 

## `graph.stream(None, to_replay.config, stream_mode="values")` 동작 원리

- 첫 번째 인자로 `None`을 넘기면, LangGraph는 **새 입력 없이** `to_replay.config`에 저장된 **체크포인트 상태**를 불러옵니다. 
- 내부적으로는 `checkpoint_id`로 과거 상태를 로드하고, `snapshot.next`에 표시된 **다음 노드**에서부터 실행을 재개합니다. 
- 이때 과거에 저장된 `messages` 리스트가 **자동으로 LLM의 컨텍스트**(프롬프트)로 주입되어, 이전 대화 흐름 그대로 이어서 처리됩니다.
- 결과적으로 “시간여행” 기능을 통해 사용자가 원하는 과거 시점부터 **오류 수정, 전략 변경, 분기(branch off)** 등을 손쉽게 실험할 수 있게 됩니다.
