### PR TITLE
Common separeted list output parser

### DIFF
--- a/outputParser/common_separated_List_OutputParser_sample_v1.py
+++ b/outputParser/common_separated_List_OutputParser_sample_v1.py
@@ -1,0 +1,60 @@
+# -----------------------------------------------------
+# 1) 필요한 클래스 임포트
+# -----------------------------------------------------
+from langchain_core.output_parsers.list import CommaSeparatedListOutputParser
+from langchain_core.prompts import PromptTemplate
+from langchain_openai import ChatOpenAI
+from dotenv import load_dotenv
+import os
+
+# -----------------------------------------------------
+# 2) 환경 변수 로딩
+# -----------------------------------------------------
+# .env 에서 OPENAI_API_KEY를 읽어 옵니다.
+load_dotenv()
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if not OPENAI_API_KEY:
+    raise RuntimeError("❌ OPENAI_API_KEY가 설정되지 않았습니다.")
+
+# -----------------------------------------------------
+# 3) 파서 초기화
+# -----------------------------------------------------
+# 쉼표로 구분된 텍스트를 리스트로 변환해 주는 파서
+parser = CommaSeparatedListOutputParser()
+
+# -----------------------------------------------------
+# 4) 프롬프트 템플릿 준비
+# -----------------------------------------------------
+# 대한민국의 주요 도시 이름을 “쉼표로 구분”하여 나열해 달라는 지시
+prompt = PromptTemplate(
+    template="{country}의 주요 도시 이름을 쉼표로 구분하여 나열해주세요.",
+    input_variables=["country"],
+)
+
+# -----------------------------------------------------
+# 5) LLM(언어 모델) 설정
+# -----------------------------------------------------
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+
+# -----------------------------------------------------
+# 6) 프롬프트와 LLM 결합 & 실행
+# -----------------------------------------------------
+chain = prompt | llm
+raw_output: str = chain.invoke({"country" : "대한민국"}).content
+
+# 프롬프트 출력 방법 -> PromptTemplate.format() 호출
+print("[prompt] " + prompt.format(country="대한민국"))
+
+# -----------------------------------------------------
+# 7) 파싱 실행
+# -----------------------------------------------------
+# 쉼표로 나누고 strip() 처리한 Python 리스트 반환
+## parser.parse()에 LLM의 원시 문자열을 넘기면, 쉼표로 나눈 뒤 각 항목을 strip() 처리한 리스트가 반환됩니다.
+## 내부적으로 raw_output.split(",") -> 항목별로 .strip() -> 최종적으로 List[str] 형태로 반환
+cities: list[str] = parser.parse(raw_output)
+
+# -----------------------------------------------------
+# 8) 결과 확인
+# -----------------------------------------------------
+print(cities)
+# 예시 출력 → ['서울', '부산', '인천', '대구', '대전', '광주', '울산', '수원', ...]

--- a/outputParser/common_separated_List_OutputParser_sample_v2.py
+++ b/outputParser/common_separated_List_OutputParser_sample_v2.py
@@ -1,0 +1,53 @@
+# -----------------------------------------------------
+# 1) 필요한 클래스 임포트
+# -----------------------------------------------------
+from langchain_core.output_parsers.list import CommaSeparatedListOutputParser
+from langchain_core.prompts import PromptTemplate
+from langchain_openai import ChatOpenAI
+from dotenv import load_dotenv
+import os
+
+# -----------------------------------------------------
+# 2) 환경 변수 로딩
+# -----------------------------------------------------
+# .env 에서 OPENAI_API_KEY를 읽어 옵니다.
+load_dotenv()
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if not OPENAI_API_KEY:
+    raise RuntimeError("❌ OPENAI_API_KEY가 설정되지 않았습니다.")
+
+# -----------------------------------------------------
+# 3) 파서 초기화
+# -----------------------------------------------------
+# 쉼표로 구분된 텍스트를 리스트로 변환해 주는 파서
+parser = CommaSeparatedListOutputParser()
+
+# -----------------------------------------------------
+# 4) 프롬프트 템플릿 준비
+# -----------------------------------------------------
+# 대한민국의 주요 도시 이름을 “쉼표로 구분”하여 나열해 달라는 지시
+prompt = PromptTemplate(
+    template=
+    "아래 형식에 맞춰 아래 질문에 응답해주세요:\n\n"
+    "형식 : {format_instructions}\n"   # → JSON 스키마와 예시가 들어감
+    "질문 : {query}"                   # → 실제 질문(프롬프트 본문)이 들어감
+    ,
+    # input_variables : 템플릿 문자열에 있는 변수와 비교하여 불일치하는 경우 예외 발생
+    input_variables=["query"],
+    # partial_variables : 항상 공통된 방식으로 가져오고 싶은 변수가 있는 경우
+    partial_variables={"format_instructions": parser.get_format_instructions()}
+)
+
+# -----------------------------------------------------
+# 5) LLM(언어 모델) 설정
+# -----------------------------------------------------
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+
+# -----------------------------------------------------
+# 6) 프롬프트와 LLM, Parser 결합 & 실행
+# -----------------------------------------------------
+chain = prompt | llm | parser
+print(chain.invoke({"query": "대한민국의 주요 도시 이름을 나열해주세요."}))
+
+# 프롬프트 출력 방법 -> PromptTemplate.format() 호출
+print("[prompt] " + prompt.format(query="대한민국의 주요 도시 이름을 나열해주세요."))


### PR DESCRIPTION
## CommaSeparatedListOutputParser

- 쉼표로 구분된 항목 목록 반환 필요가 있을때 유용
- 사용자가 입력한 데이터나 요청한 정보를 쉼표로 구분하여 명확하고 간결한 목록 형태로 제공받을 수 있음
	- 여러개의 데이터 포인트, 이름, 항목 또는 다른 종류의 값들을 나열
- 정보를 구조화하고 가독성을 높이며 특히 데이터를 다루거나 리스트 형태의 결과를 요구하는 경우 매우 유용
- 반환 타입 : List[str] 

## v1 구현

- LLM의 응답 중 content 추출 (AIMessage에서 content)
- 해당 내용을 parser를 이용해서 리스트로 추출하여 출력

## v2 구현

- 프롬프트 구성에 응답 형식 명시적으로 지정
  - PydanticOutputParser와 동일하게 `get_format_instructions` 메서드로 언어 모델이 출력해야 하는 형식 지정

```
아래 형식에 맞춰 아래 질문에 응답해주세요:

형식 : Your response should be a list of comma separated values, eg: `foo, bar, baz` or `foo,bar,baz`
질문 : 대한민국의 주요 도시 이름을 나열해주세요.
```

- Your response should be a list of comma separated values, eg: `foo, bar, baz` or `foo,bar,baz`
> 응답은 쉼표로 구분된 값 목록이어야 합니다. 예를 들어, 'foo, bar, baz' 또는 'foo, bar, baz'입니다

- 출력
```python
['서울', '부산', '대구', '인천', '광주', '대전', '울산', '경기도', '세종', '제주']
```

- 언어 모델에 출력 형태를 프롬프트에 명시하고, chain을 파이프 메서드로 연결하면 parser를 별도로 실행시키지 않고도 바로 실행된다.

```python
chain = prompt | llm | parser
```