### PR TITLE
Few Shot Prompt 챕터 완성

### DIFF
--- a/prompt/few_shot_chat_message_prompt_template.py
+++ b/prompt/few_shot_chat_message_prompt_template.py
@@ -1,0 +1,140 @@
+from langchain_core.output_parsers import StrOutputParser
+
+examples = [
+    {
+        "instruction": "당신은 회의록 작성 전문가 입니다. 주어진 정보를 바탕으로 회의록을 작성해 주세요",
+        "input": "2023년 12월 25일, XYZ 회사의 마케팅 전략 회의가 오후 3시에 시작되었다. 회의에는 마케팅 팀장인 김수진, 디지털 마케팅 담당자인 박지민, 소셜 미디어 관리자인 이준호가 참석했다. 회의의 주요 목적은 2024년 상반기 마케팅 전략을 수립하고, 새로운 소셜 미디어 캠페인에 대한 아이디어를 논의하는 것이었다. 팀장인 김수진은 최근 시장 동향에 대한 간략한 개요를 제공했으며, 이어서 각 팀원이 자신의 분야에서의 전략적 아이디어를 발표했다.",
+        "answer": """
+회의록: XYZ 회사 마케팅 전략 회의
+일시: 2023년 12월 25일
+장소: XYZ 회사 회의실
+참석자: 김수진 (마케팅 팀장), 박지민 (디지털 마케팅 담당자), 이준호 (소셜 미디어 관리자)
+
+1. 개회
+   - 회의는 김수진 팀장의 개회사로 시작됨.
+   - 회의의 목적은 2024년 상반기 마케팅 전략 수립 및 새로운 소셜 미디어 캠페인 아이디어 논의.
+
+2. 시장 동향 개요 (김수진)
+   - 김수진 팀장은 최근 시장 동향에 대한 분석을 제시.
+   - 소비자 행동 변화와 경쟁사 전략에 대한 통찰 공유.
+
+3. 디지털 마케팅 전략 (박지민)
+   - 박지민은 디지털 마케팅 전략에 대해 발표.
+   - 온라인 광고와 SEO 최적화 방안에 중점을 둠.
+
+4. 소셜 미디어 캠페인 (이준호)
+   - 이준호는 새로운 소셜 미디어 캠페인에 대한 아이디어를 제안.
+   - 인플루언서 마케팅과 콘텐츠 전략에 대한 계획을 설명함.
+
+5. 종합 논의
+   - 팀원들 간의 아이디어 공유 및 토론.
+   - 각 전략에 대한 예산 및 자원 배분에 대해 논의.
+
+6. 마무리
+   - 다음 회의 날짜 및 시간 확정.
+   - 회의록 정리 및 배포는 박지민 담당.
+""",
+    },
+    {
+        "instruction": "당신은 요약 전문가 입니다. 다음 주어진 정보를 바탕으로 내용을 요약해 주세요",
+        "input": "이 문서는 '지속 가능한 도시 개발을 위한 전략'에 대한 20페이지 분량의 보고서입니다. 보고서는 지속 가능한 도시 개발의 중요성, 현재 도시화의 문제점, 그리고 도시 개발을 지속 가능하게 만들기 위한 다양한 전략을 포괄적으로 다루고 있습니다. 이 보고서는 또한 성공적인 지속 가능한 도시 개발 사례를 여러 국가에서 소개하고, 이러한 사례들을 통해 얻은 교훈을 요약하고 있습니다.",
+        "answer": """
+문서 요약: 지속 가능한 도시 개발을 위한 전략 보고서
+
+- 중요성: 지속 가능한 도시 개발이 필수적인 이유와 그에 따른 사회적, 경제적, 환경적 이익을 강조.
+- 현 문제점: 현재의 도시화 과정에서 발생하는 주요 문제점들, 예를 들어 환경 오염, 자원 고갈, 불평등 증가 등을 분석.
+- 전략: 지속 가능한 도시 개발을 달성하기 위한 다양한 전략 제시. 이에는 친환경 건축, 대중교통 개선, 에너지 효율성 증대, 지역사회 참여 강화 등이 포함됨.
+- 사례 연구: 전 세계 여러 도시의 성공적인 지속 가능한 개발 사례를 소개. 예를 들어, 덴마크의 코펜하겐, 일본의 요코하마 등의 사례를 통해 실현 가능한 전략들을 설명.
+- 교훈: 이러한 사례들에서 얻은 주요 교훈을 요약. 강조된 교훈에는 다각적 접근의 중요성, 지역사회와의 협력, 장기적 계획의 필요성 등이 포함됨.
+
+이 보고서는 지속 가능한 도시 개발이 어떻게 현실적이고 효과적인 형태로 이루어질 수 있는지에 대한 심도 있는 분석을 제공합니다.
+""",
+    },
+    {
+        "instruction": "당신은 문장 교정 전문가 입니다. 다음 주어진 문장을 교정해 주세요",
+        "input": "우리 회사는 새로운 마케팅 전략을 도입하려고 한다. 이를 통해 고객과의 소통이 더 효과적이 될 것이다.",
+        "answer": "본 회사는 새로운 마케팅 전략을 도입함으로써, 고객과의 소통을 보다 효과적으로 개선할 수 있을 것으로 기대된다.",
+    },
+]
+
+# =====================================================
+# 0) 환경 변수 로딩
+# =====================================================
+# .env 파일에 저장된 OPENAI_API_KEY를 불러옵니다.
+from dotenv import load_dotenv
+import os
+
+load_dotenv()  # .env 파일을 읽어 환경 변수로 설정
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if not OPENAI_API_KEY:
+    raise RuntimeError("❌ OPENAI_API_KEY가 설정되지 않았습니다. .env 파일을 확인하세요.")
+
+# =====================================================
+# 1) OpenAI 임베딩 및 LLM 객체 생성
+# =====================================================
+# 임베딩 모델: 텍스트를 고정 길이 벡터(숫자 배열)로 변환
+# 가장 저렴한 'text-embedding-3-small' 모델 사용
+from langchain_openai import OpenAIEmbeddings
+embeddings = OpenAIEmbeddings(model="text-embedding-3-small")
+
+# LLM: 실제 프롬프트를 입력받아 답변을 생성
+from langchain_openai import ChatOpenAI
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+# temperature=0 으로 설정하면, 동일한 프롬프트에 대해 항상 같은 결과를 얻습니다.
+
+
+from langchain_chroma import Chroma
+chroma = Chroma("fewshot_chat", embeddings)
+
+from langchain_core.prompts import ChatPromptTemplate, FewShotChatMessagePromptTemplate
+example_prompt = ChatPromptTemplate.from_messages(
+    [
+        ("human", "{instruction}:\n{input}"),
+        ("ai", "{answer}"),
+    ]
+)
+
+from langchain_core.example_selectors import (
+    SemanticSimilarityExampleSelector,
+)
+
+example_selector = SemanticSimilarityExampleSelector.from_examples(
+    # 여기에는 선택 가능한 예시 목록이 있습니다.
+    examples,
+    # 여기에는 의미적 유사성을 측정하는 데 사용되는 임베딩을 생성하는 임베딩 클래스가 있습니다.
+    embeddings,
+    # 여기에는 임베딩을 저장하고 유사성 검색을 수행하는 데 사용되는 VectorStore 클래스가 있습니다.
+    chroma,
+    # 이것은 생성할 예시의 수입니다.
+    k=1,
+)
+
+few_shot_prompt = FewShotChatMessagePromptTemplate(
+    example_selector=example_selector,
+    example_prompt=example_prompt,
+)
+
+question = {
+    "instruction": "회의록을 작성해 주세요",
+    "input": "2023년 12월 26일, ABC 기술 회사의 제품 개발 팀은 새로운 모바일 애플리케이션 프로젝트에 대한 주간 진행 상황 회의를 가졌다. 이 회의에는 프로젝트 매니저인 최현수, 주요 개발자인 황지연, UI/UX 디자이너인 김태영이 참석했다. 회의의 주요 목적은 프로젝트의 현재 진행 상황을 검토하고, 다가오는 마일스톤에 대한 계획을 수립하는 것이었다. 각 팀원은 자신의 작업 영역에 대한 업데이트를 제공했고, 팀은 다음 주까지의 목표를 설정했다.",
+}
+
+print(example_selector.select_examples(question))
+
+final_prompt = ChatPromptTemplate.from_messages(
+    [
+        (
+            "system",
+            "You are a helpful assistant.",
+        ),
+        few_shot_prompt,
+        ("human", "{instruction}\n{input}"),
+    ]
+)
+
+# chain 생성
+chain = final_prompt | llm | StrOutputParser()
+
+# 실행 및 결과 출력
+answer = chain.invoke(question)
+print(answer)

--- a/prompt/fewshot_prompt_template.py
+++ b/prompt/fewshot_prompt_template.py
@@ -1,0 +1,135 @@
+# =====================================================
+# 0) 환경 변수 로딩
+# =====================================================
+# .env 파일에 저장된 OPENAI_API_KEY를 불러옵니다.
+from dotenv import load_dotenv
+import os
+
+load_dotenv()  # .env 파일을 읽어 환경 변수로 설정
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if not OPENAI_API_KEY:
+    # API 키가 없으면 실행을 중단하고 에러를 출력합니다.
+    raise RuntimeError("❌ OPENAI_API_KEY가 설정되지 않았습니다. .env 파일을 확인하세요.")
+
+# =====================================================
+# 1) LLM 객체 생성
+# =====================================================
+# langchain_openai 패키지의 ChatOpenAI 클래스로 LLM 인스턴스를 만듭니다.
+from langchain_openai import ChatOpenAI
+
+# temperature=0 으로 설정하면 매번 동일한 답변을 얻도록 고정합니다.
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+
+# =====================================================
+# 2) Few-Shot 예제 및 프롬프트 템플릿 정의
+# =====================================================
+from langchain_core.prompts.few_shot import FewShotPromptTemplate
+from langchain_core.prompts import PromptTemplate
+
+# 2-1) 예제 입력-출력 쌍을 리스트로 정의
+examples = [
+    {
+        "question": "스티브 잡스와 아인슈타인 중 누가 더 오래 살았나요?",
+        "answer": "아인슈타인"
+    },
+    {
+        "question": "네이버의 창립자는 누구인가요?",
+        "answer": "이해진"
+    },
+    {
+        "question": "연산군은 어느 연도에 즉위했나요?",
+        "answer": "1504년"
+    }
+]
+
+# 2-2) 예제 하나를 출력할 때 사용할 포맷을 정의
+#    {question}과 {answer} 자리에 실제 데이터를 넣어줍니다.
+example_prompt = PromptTemplate(
+    template="Question: {question}\nAnswer: {answer}",
+    input_variables=["question", "answer"],
+)
+
+# 2-3) FewShotPromptTemplate 생성
+#    - examples: 실제 예제 리스트
+#    - example_prompt: 위에서 정의한 포맷, question과 answer를 어떤 형태로 넣을지 정의
+#    - suffix: 모델에게 전달할 최종 프롬프트 끝부분, 모든 예제를 보여준 뒤 실제 사용자 질문을 받기 위해 붙이는 텍스트
+#    - input_variables: 사용자 질문 변수 이름
+#    - example_separator(선택) : 예제 사이 구분자 , 기본값운 \n\n / 변경 가능
+#    - prefix(선택) : 예제 앞에 붙일 초기 지시문, 예제가 나오기 전 모델에게 태스크 설명 등을 미리 던질때 사용
+few_shot_prompt = FewShotPromptTemplate(
+    # prefix 옵션 추가
+    prefix="다음 예시를 참고하여 질문에 답변해주세요.\n\n", # 생략 가능
+    examples=examples,
+    example_prompt=example_prompt,
+    suffix="Question: {question}\n",
+    input_variables=["question"],
+    example_separator="\n\n"  # 예제 사이 줄바꿈 두 줄로 구분, 기본값으로 생략 가능
+)
+
+# =====================================================
+# 3) 출력 파서 및 GraphState 정의
+# =====================================================
+from langchain_core.output_parsers import StrOutputParser
+from langgraph.graph import StateGraph, START, END
+from pydantic import BaseModel
+
+# 3-1) GraphState 클래스
+#    - state에 담길 데이터 구조를 정의합니다.
+#    - question: 사용자 질문(필수)
+#    - answer: 모델이 생성한 답변(초기값은 빈 문자열)
+class GraphState(BaseModel):
+    question: str
+    answer: str = ""
+
+# =====================================================
+# 4) 노드 함수 정의: few_shot_node
+# =====================================================
+def few_shot_node(state: GraphState) -> dict:
+    """
+    1) Few-Shot 프롬프트 생성
+    2) LLM 호출
+    3) 문자열 출력 파싱
+    4) 결과를 {'answer': ...} 형태로 반환
+    """
+    # 체인: few_shot_prompt → llm → StrOutputParser()
+    chain = few_shot_prompt | llm | StrOutputParser()
+    # invoke에 딕셔너리 형태로 입력을 넘겨줍니다.
+    answer = chain.invoke({"question": state.question})
+    # 상태의 answer 필드만 업데이트하기 위해 dict로 반환
+    return {"answer": answer}
+
+# =====================================================
+# 5) StateGraph 구성 및 실행
+# =====================================================
+# 5-1) StateGraph 생성: 상태 스키마로 GraphState 사용
+pipeline = StateGraph(GraphState)
+
+# 5-2) 노드 추가
+pipeline.add_node("few_shot", few_shot_node)
+
+# 5-3) 시작(START) → few_shot → 끝(END) 연결
+pipeline.add_edge(START, "few_shot")
+pipeline.add_edge("few_shot", END)
+
+# 5-4) 그래프 컴파일
+graph = pipeline.compile()
+
+# =====================================================
+# 5) 사용자 입력 받기 및 결과 출력
+# =====================================================
+# 콘솔에 메시지를 띄우고, 사용자가 직접 질문을 입력하도록 함
+user_question = input("👉 질문을 입력하세요: ")
+
+# PromptTemplate이 조합한 전체 프롬프트 문자열 생성
+full_prompt = few_shot_prompt.format(question=user_question)
+
+# prefix, example1~N, suffix 순서대로 출력
+print("\n===== 생성된 전체 프롬프트 =====")
+print(full_prompt)
+print("================================\n")
+
+# GraphState 인스턴스를 생성해 그래프에 넘김
+result = graph.invoke(GraphState(question=user_question))
+
+# 최종 answer 출력
+print("\n💡 답변:", result["answer"])

--- a/prompt/length_based_example_selector.py
+++ b/prompt/length_based_example_selector.py
@@ -1,0 +1,113 @@
+# =====================================================
+# 0) 환경 변수 로딩
+# =====================================================
+# .env 파일에 저장된 OPENAI_API_KEY를 불러옵니다.
+from dotenv import load_dotenv
+import os
+
+load_dotenv()  # .env 파일을 읽어 환경 변수로 설정
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if not OPENAI_API_KEY:
+    raise RuntimeError("❌ OPENAI_API_KEY가 설정되지 않았습니다. .env 파일을 확인하세요.")
+
+# =====================================================
+# 1) LLM 객체 생성
+# =====================================================
+# langchain_openai 패키지의 ChatOpenAI 클래스로 LLM 인스턴스를 만듭니다.
+from langchain_openai import ChatOpenAI
+
+# temperature=0 으로 설정하면 동일한 입력에 대해 항상 같은 답변을 얻을 수 있습니다.
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+
+# =====================================================
+# 2) Few-Shot 예제 및 포맷 정의
+# =====================================================
+from langchain_core.prompts import PromptTemplate
+from langchain_core.prompts.few_shot import FewShotPromptTemplate
+
+# 2-1) 모델에게 보여줄 “예제 질문-응답” 리스트
+examples = [
+    {
+        "question": "스티브 잡스와 아인슈타인 중 누가 더 오래 살았나요?",
+        "answer": "아인슈타인"
+    },
+    {
+        "question": "네이버의 창립자는 누구인가요?",
+        "answer": "이해진"
+    },
+    {
+        "question": "연산군은 어느 연도에 즉위했나요?",
+        "answer": "1504년"
+    },
+    {
+        "question": "파이썬의 창시자는 누구인가요?",
+        "answer": "귀도 반 로섬"
+    },
+    {
+        "question": "세계 최초의 웹 브라우저 이름은?",
+        "answer": "WorldWideWeb"
+    }
+]
+
+# 2-2) 예제 하나를 어떻게 문자열로 만들지 포맷 정의
+example_prompt = PromptTemplate(
+    template="Question: {question}\nAnswer: {answer}",
+    input_variables=["question", "answer"],
+)
+
+# =====================================================
+# 3) ExampleSelector 생성 (길이 기반)
+# =====================================================
+from langchain_core.example_selectors.length_based import LengthBasedExampleSelector
+
+# LengthBasedExampleSelector:
+#  - examples: 사용할 전체 예제 리스트
+#  - example_prompt: 각 예제를 포맷팅할 템플릿
+#  - max_length: “예제 문자열 전체 길이(단어 기준)”이 이 값을 넘지 않도록 예제를 선택
+#  - get_text_length : 길이 추출 방식 지정 가능
+selector = LengthBasedExampleSelector(
+    examples=examples,
+    example_prompt=example_prompt,
+    max_length=20,  # 단어수 (기본), get_text_length 지정하면 해당 함수대로 길이 추출
+    # get_text_length=lambda txt: len(txt) ## 커스텀으로 길이 추출하는 방식 지정 가능
+)
+
+# =====================================================
+# 4) FewShotPromptTemplate 생성 (selector 사용)
+# =====================================================
+few_shot_prompt = FewShotPromptTemplate(
+    # ★ 여기서 examples 대신 example_selector를 전달합니다.
+    example_selector=selector,
+    example_prompt=example_prompt,
+    # prefix: 예제들 앞에 붙일 “모델 지시문”
+    prefix="아래 예시를 참고하여, 질문에 답변해주세요.\n\n",
+    # suffix: 예제 뒤에 붙여서 실제 사용자 질문을 받을 자리
+    suffix="Question: {question}\n",
+    input_variables=["question"],
+    example_separator="\n\n"  # 예제 사이에 빈 줄 2개로 구분
+)
+
+# =====================================================
+# 5) 사용자 입력 받기 및 포맷된 프롬프트 확인
+# =====================================================
+# 터미널(콘솔)에서 질문을 직접 입력받습니다.
+user_question = input("👉 질문을 입력하세요: ")
+
+# FewShotPromptTemplate이 만들어 내는 “전체 프롬프트 문자열”
+full_prompt = few_shot_prompt.format(question=user_question)
+
+# prefix, 선택된 example1~N, suffix 순서로 출력됩니다.
+print("\n===== 생성된 전체 프롬프트 =====")
+print(full_prompt)
+print("================================\n")
+
+# =====================================================
+# 6) LLM 호출 및 답변 출력
+# =====================================================
+from langchain_core.output_parsers import StrOutputParser
+
+chain = few_shot_prompt | llm | StrOutputParser()
+
+answer = chain.invoke({"question": user_question})
+
+print("💡 답변:", answer)

--- a/prompt/semantic_similarity_example_selector.py
+++ b/prompt/semantic_similarity_example_selector.py
@@ -1,0 +1,126 @@
+# =====================================================
+# 0) 라이브러리 임포트 및 환경 변수 로딩
+# =====================================================
+from dotenv import load_dotenv             # .env 파일에서 환경 변수를 읽어오는 모듈
+import os                                  # 운영체제 환경 변수를 다루는 모듈
+
+# OpenAI 결과를 문자열로 파싱하는 도구
+from langchain_core.output_parsers import StrOutputParser
+# Few-Shot Prompt 구성에 필요한 템플릿 클래스
+from langchain_core.prompts import (
+    PromptTemplate,
+    FewShotPromptTemplate
+)
+
+from langchain_core.example_selectors import (
+        SemanticSimilarityExampleSelector
+)
+
+# .env 파일을 읽어들여 환경 변수를 설정
+load_dotenv()
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if not OPENAI_API_KEY:
+    raise RuntimeError("❌ OPENAI_API_KEY가 설정되지 않았습니다. .env 파일을 확인하세요.")
+
+
+# =====================================================
+# 1) OpenAI 임베딩 및 LLM 객체 생성
+# =====================================================
+# 임베딩 모델: 텍스트를 고정 길이 벡터(숫자 배열)로 변환
+# 가장 저렴한 'text-embedding-3-small' 모델 사용
+from langchain_openai import OpenAIEmbeddings
+embeddings = OpenAIEmbeddings(model="text-embedding-3-small")
+
+# LLM: 실제 프롬프트를 입력받아 답변을 생성
+from langchain_openai import ChatOpenAI
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+# temperature=0 으로 설정하면, 동일한 프롬프트에 대해 항상 같은 결과를 얻습니다.
+
+
+# =====================================================
+# 2) ChromaDB 클라이언트 초기화
+# =====================================================
+# Chroma: 파이썬 라이브러리 형태의 벡터 데이터베이스
+# - 별도 서버 없이 로컬(메모리 또는 디스크)에 벡터를 저장하고
+#   빠른 유사도 검색을 지원합니다.
+from langchain_chroma import Chroma
+
+# Vector DB 생성 (저장소 이름, 임베딩 클래스)
+chroma_collection = Chroma("example_selector", embeddings)
+
+# =====================================================
+# 3) 예제(question-answer) 목록 및 포맷 정의
+# =====================================================
+# 3-1) 모델에게 보여줄 “예제 질문-응답” 리스트
+examples = [
+    {"question": "스티브 잡스와 아인슈타인 중 누가 더 오래 살았나요?", "answer": "아인슈타인"},
+    {"question": "네이버의 창립자는 누구인가요?",              "answer": "이해진"},
+    {"question": "연산군은 어느 연도에 즉위했나요?",            "answer": "1504년"},
+    {"question": "파이썬의 창시자는 누구인가요?",             "answer": "귀도 반 로섬"},
+    {"question": "세계 최초의 웹 브라우저 이름은?",            "answer": "WorldWideWeb"},
+]
+
+# 3-2) 예제 하나를 문자열로 만들 때 사용할 템플릿
+#    {question}과 {answer} 자리에 실제 값을 대입합니다.
+example_prompt = PromptTemplate(
+    template="Question: {question}\nAnswer: {answer}",
+    input_variables=["question", "answer"],
+)
+
+# =====================================================
+# 4) SemanticSimilarityExampleSelector 설정
+# =====================================================
+# SemanticSimilarityExampleSelector:
+# - 미리 저장한 예제 벡터들과 사용자 질문 벡터를 비교해
+#   의미적으로 가장 유사한 예제 k개를 자동으로 골라주는 도구.
+
+example_selector = SemanticSimilarityExampleSelector.from_examples(
+    # 선택 가능한 예시 목록
+    examples,
+    # 의미적 유사성을 측정하는 데 사용되는 임베딩을 생성하는 임베딩 클래스
+    embeddings,
+    # 임베딩을 저장하고 유사성 검색을 수행하는 데 사용되는 VectorStore 클래스
+    ## Chroma로 사용 - from_examples 내부에서 Chroma("example_selector", embeddings)를 자동으로 생성하여 벡터 저장소 세팅
+        ## vectorstore_cls: type[VectorStore] 이기 때문에 노란줄 안뜸
+        ## 하지만 명시적으로 인스턴스를 지정하면 노란줄 뜸 -> 런타임 시 호출 가능하면 내부에서 실행하려 시도 -> 오류x
+    chroma_collection,
+    # 이것은 생성할 예시의 수입니다.
+    k=1,
+)
+
+
+# =====================================================
+# 5) Few-Shot PromptTemplate에 selector 연결
+# =====================================================
+# FewShotPromptTemplate:
+# - example_selector: 위에서 만든 selector 사용 → 자동으로 k개 예제 검색
+# - example_prompt: 3-2)에서 정의한 포맷
+# - prefix: 예제들 앞에 붙일 “지시문”
+# - suffix: 예제 뒤에 “실제 질문 자리”
+# - example_separator: 예제 간 구분 문자
+few_shot_prompt = FewShotPromptTemplate(
+    example_selector=example_selector,
+    example_prompt=example_prompt,
+    prefix="아래 예시와 비슷한 한 가지 예시를 참고해 질문에 답변해주세요.\n\n",
+    suffix="Question: {question}\nAnswer:",
+    input_variables=["question"],
+    example_separator="\n\n"
+)
+
+
+# =====================================================
+# 6) 사용자 입력 받아 실행 및 결과 출력
+# =====================================================
+# 6-1) 콘솔에서 질문 입력 받기
+user_question = input("👉 질문을 입력하세요: ")
+
+# 6-2) Few-Shot Prompt 전체 문자열 확인 (디버그용)
+print("\n=== 생성된 Prompt ===")
+print(few_shot_prompt.format(question=user_question))
+print("=====================\n")
+
+# 6-3) LLM 호출 후, 문자열만 추출해 출력
+chain = few_shot_prompt | llm | StrOutputParser()
+answer = chain.invoke({"question": user_question})
+
+print("💡 답변:", answer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "grandalf (>=0.8,<0.9)",
     "langchain-tavily (>=0.1.5,<0.2.0)",
     "pydantic (>=2.11.4,<3.0.0)",
+    "langchain-chroma (>=0.2.4,<0.3.0)",
+    "langchain-community (>=0.3.24,<0.4.0)",
 ]
 
 


### PR DESCRIPTION
# Few Shot Prompt

- 모델에 예제 입력-출력 쌍을 제공하여 원하는 출력 형태를 학습시키는 기법
  - 소량의 예제만으로 모델 성능을 크게 향상시킬 수 있습니다.
- LangGraph는 LangChain의 PromptTemplate, FewShotPromptTemplate 등을 그대로 활용해 노드 단위로 Few-Shot Prompt를 실행할 수 있습니다.

## Few-Shot Prompting이란?
- 프롬프트에 2~5개의 예제 입력-출력 쌍을 포함시켜 모델에게 원하는 태스크 수행 기법
- 대규모 언어 모델이 사전 학습된 지식과 주어진 예제를 참고해 새 문제를 해결하도록 유도

### 옵션

| 옵션 이름                      | 설명                                                                                                                                                                                          |
| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `examples`                 | ● **예제의 리스트**<br>  - 각 예제는 `dict` 형태로, 모델에게 보여줄 **입력(question)과 출력(answer)** 쌍을 담습니다.                                                                                                       |
| `example_prompt`           | ● **예제 하나를 포맷팅할 방법**<br>  - `PromptTemplate`를 사용해 `{question}`과 `{answer}`를 어떤 형식으로 넣을지 정의합니다.                                                                                              |
| `suffix`                   | ● **예제 뒤에 붙일 “마지막 지시문”**<br>  - 모든 예제를 보여 준 뒤, 실제 사용자 질문을 받기 위해 붙이는 텍스트입니다.  <br>  예) `"Question: {question}\nAnswer:"`                                                                     |
| `prefix` *(선택)*            | ● **예제 앞에 붙일 “초기 지시문”**<br>  - 예제가 나오기 전에 모델에게 태스크 설명 등을 미리 던질 때 사용합니다.                                                                                                                     |
| `input_variables`          | ● **최종 프롬프트에서 치환할 변수 이름들**<br>  - `suffix`나 `prefix`에 쓸 `{question}` 등, 외부에서 값을 넣어 줄 변수 이름 리스트입니다.                                                                                          |
| `example_separator` *(선택)* | ● **예제 사이에 들어갈 구분자**<br>  - 기본값은 `"\n\n"`으로, 예제와 예제 사이를 띄워 쓰고 싶을 때 변경 가능합니다.                                                                                                                |
| `example_selector`(선택)     | ● `FewShotPromptTemplate`(`FewShotChatMessagePromptTemplate` 포함)에 예제 선택 로직을 주입할 수 있는 옵션<br>- `format()` 또는 체인 실행 시(`\| llm \| …`)마다 `example_selector.select_examples()` 호출<br>- 기본값 : None |


- Few-Shot Prompt 적용 시 아래와 같은 형태
```xml
<prefix>
<example1>
<example2> 
... 
<exampleN> 
<suffix>
```

- 예시
```text
다음 예시를 참고하여 질문에 답변해주세요.



Question: 스티브 잡스와 아인슈타인 중 누가 더 오래 살았나요?
Answer: 아인슈타인

Question: 네이버의 창립자는 누구인가요?
Answer: 이해진

Question: 연산군은 어느 연도에 즉위했나요?
Answer: 1504년

Question: "Google이 창립된 연도에 Bill Gates의 나이는 몇 살인가요?"


```
## Zero-Shot/One-Shot vs Few-Shot
- Zero-Shot : 예제 없이 태스크 설명만 제공
- One-Shot : 하나의 예제 제공
- Few-Shot : 소량(보통 3~5개)의 예제 제공
	- 복잡한 태스크에서 성능과 일관성을 크게 향상시키며 예제 개수와 품질에 따라 결과 달라짐


----------

## Example Selector

- 다수의 예제 중 지금 이 입력에 가장 적합한 예제만 골라서 프롬프트에 넣어주는 도구
- 대표적인 예시로 `LengthBasedExampleSelector` 존재
	- 입력 질문의 길이에 따라 자동으로 포함될 예제 수 조절
	- 프롬프트의 길이가 너무 길어지면 모델 비용이 늘어나거나 토큰 제한에 걸릴 수 있음
	- 길이 기반 선택자는 입력 길이에 맞춰 사용할 예제 수를 자동으로 줄여 이런 문제 발생 예방

### LengthBasedExampleSelector 동작
- `max_length`를 기준으로 예제 문자열 전체 단어 수 계산
	- `max_length`는 개별 예제가 아닌 위에서부터 예제를 하나씩 더해가며 누적된 길이 기준
		- 첫 번째 예제의 길이 더함
		- 두 번째 예제를 더했을 때 누적 길이가 `max_length`보다 크면 두 번째 예외부터 제외
		- 위 과정을 반복하며 누적 합이 범위 안에 드는 예제들만 남기는 방식
- 입력이 짧을 떄는 더 많은 예제를 포함하고 입력이 길어질수록 자동으로 예제 수를 줄여줌
	- `few_shot_prompt.format(...)` 호출 시 내부에서 `selector.select_examples({"question" : user_question})` 을 수행
	- `user_question` 길이에 맞는 예제 리스트를 리턴받고 그 예제들만 `prefix` -> `예제` -> `suffix` 순으로 조합
- 예시
	- max_length 20으로 했을때 예제 2개만 나옴
```text
👉 질문을 입력하세요: 오늘 날씨 어때?

===== 생성된 전체 프롬프트 =====
아래 예시를 참고하여, 질문에 답변해주세요.



Question: 스티브 잡스와 아인슈타인 중 누가 더 오래 살았나요?
Answer: 아인슈타인

Question: 네이버의 창립자는 누구인가요?
Answer: 이해진

Question: 오늘 날씨 어때?

================================

💡 답변: Answer: 현재 날씨 정보를 제공할 수 없지만, 지역의 기상청 웹사이트나 날씨 앱을 확인하시면 정확한 정보를 얻을 수 있습니다.
```


### SemanticSimilarityExampleSelector
- 의미 유사도 기반으로 예제 자동 선택
- 동작 방식
	- 사용자 질문 임베딩
	- 컬렉션에 저장된 예제 벡터들과 코사인 유사도 비교
	- 가장 유사한 k개 반환

```python
from langchain_core.example_selectors import SemanticSimilarityExampleSelector

example_selector = SemanticSimilarityExampleSelector.from_examples(
  examples,      # (1) 선택 후보 예제 리스트
  embeddings,    # (2) 벡터 변환에 사용할 임베딩 객체
  Chroma,        # (3) 벡터를 저장·검색할 벡터스토어 클래스
  k=1            # (4) 꺼내올 예제 개수
)
```
- `from_examples` 편의 메서드 역할
	- 예제 임베딩 -> 저장 과정을 내부에서 처리하기에 직접 저장 코드 추가할 필요가 없음
	- `examples`를 내부에서 한번에 임베딩 -> `Chroma`에 저장(upsert)
	- `select_examples()` 호출 시 곧바로 검색이 가능하도록 준비
		- `.format()` 메서드 내부에서 호출함
	- `Chroma("example_selector", embeddings)`를 **자동 생성**하여  벡터 저장소 세팅
		- Chroma라고 할경우
		- 실제 객체를 만들어서 넣어주면 생성한 컬렉션 사용

- Few-Shot PromptTemplate에 selector 연결
	- `example_selector` 옵션을 주면 `few_shot_prompt.format(question=...)` 호출 시 마다
		- 사용자 질문 임베딩
		- Chroma에서 유사도 검색
		- 가장 유사한 예제 1개 가져옴
		- prefix -> 예제 -> suffix 순으로 자동 조합
```python
few_shot_prompt = FewShotPromptTemplate(
  example_selector=example_selector,   # 4)에서 만든 selector
  example_prompt=example_prompt,       # 3-2) 예제 포맷
  prefix="아래 예시와 비슷한 한 가지 예시를 참고해 질문에 답변해주세요.\n\n",
  suffix="Question: {question}\nAnswer:",
  input_variables=["question"],
  example_separator="\n\n"
)
```

### Chroma
- 파이썬 라이브러리 형태 벡터 저장소
	- 별도 서버 없이 로컬에서 임베딩 벡터 저장, 탐색
	- 도커나 외부 DB 불필요

- 내부에 인스턴스 생성
	- 컬렉션 생성
	- 벡터 data 저장할 준비 마침

------

## FewShotChatMessagePromptTemplate

- 채팅 형식의 메시지를 구성할 때 사용되는 템플릿
  - `ChatPromptTemplate.from_messages` 로 정의된 “human/ai” 메시지 패턴을 반복 적용한 대화형 시나리오 생성
    - 프롬프트 시작(system)  
    - 예제 메시지(human→ai)  
    - 사용자 질문(human)  
    
- **주요 특징**  
```python
few_shot_prompt = FewShotChatMessagePromptTemplate(  
    example_selector=example_selector,  # 예제 선택
    example_prompt=example_prompt,  # 형식 선택(ChatPromptTemplate)
)
```
  - 예제 하나당 `("human", "{instruction}\n{input}")` → `("ai", "{answer}")` 메시지 쌍 포맷팅
```python
[("human", "{instruction}\n{input}"), ("ai", "{answer}")]
```
- 정의한 `ChatPromptTemplate` 형식
  - `example_selector` 로 검색된 예제 메시지만 자동 삽입  
  - 최종 `ChatPromptTemplate` 체인(`system`→`few_shot_prompt`→`human`)에 그대로 연결 가능
```python
final_prompt = ChatPromptTemplate.from_messages(  
    [  
        (  
            "system",  
            "You are a helpful assistant.",  
        ),  
        few_shot_prompt,  
        ("human", "{instruction}\n{input}"),  
    ]  
)
```
### CustomExampleSelector
- 기존 구현 코드에서 예시 데이터를 임베딩할때 dictionary 형태를 하나의 문자열로 합쳐서 임베딩
	- `"instruction": "ins1"\n"input":"input1"\n"answer":"anwer1~"`
- 그래서 사용자 질문할 때 아래와 같이 instruction과 input을 같이 줘서 의미 유사도 검색을 한다.
```python
question = {  
    "instruction": "회의록을 작성해 주세요",  
    "input": "2023년 12월 26일, ABC 기술 회사의 제품 개발 팀은 새로운 모바일 애플리케이션 프로젝트에 대한 주간 진행 상황 회의를 가졌다. 이 회의에는 프로젝트 매니저인 최현수, 주요 개발자인 황지연, UI/UX 디자이너인 김태영이 참석했다. 회의의 주요 목적은 프로젝트의 현재 진행 상황을 검토하고, 다가오는 마일스톤에 대한 계획을 수립하는 것이었다. 각 팀원은 자신의 작업 영역에 대한 업데이트를 제공했고, 팀은 다음 주까지의 목표를 설정했다.",  
}

```
- 하지만  `instruction` 이나 `input`으로만, 즉 임베딩 키의 일부만으로 검색하면 어떻게 될까?
	- 당연히 정확도가 떨어진다.
		- 임베딩을 `insturction + input + answer`  조합으로 했기 때문이다.
	- 그러면 이제 만약 특정 키로만 검색해야 한다면?
		- 해당 검색하고자 하는 키만 임베딩을 한 데이터를 쌓고
		- 그 다음에 질의로 검색하면 정확도를 높일 수 있다.

- 테디노트에서 구현한 CustomExampleSelector는 아래와 같다.
	- `example_embeddings = [(원본 내용, 해당 키로 임베딩값)]`
	- 위 형태기 때문에 비교를 튜플에서 2번째인 임베딩값과 유사도를 비교한다!

```python
# 모든 예제에 대한 임베딩을 사전 계산합니다.
self.example_embeddings = [
	(example, self.embedding_model.embed_query(example[search_key]))
	for example in examples
]
```


- 구체 예시 코드는 라이브러리를 추가해서 작성해야 하는데 개인적으로 느끼기에 직관적으로 보이지 않아 위 설명을 추가하는 것으로 대체합니다.
	- [CustomExampleSelector 정의](https://github.com/teddylee777/langchain-teddynote/blob/e150419a7eaba5ec154df2b318602968e24f5537/langchain_teddynote/prompts.py#L26)
	- [CustomExampleSelector 예시 - 테디노트 위키독스](https://wikidocs.net/233348#example-selector_1)
