### PR TITLE
Hugging Face EndPoint 챕터 완성

### DIFF
--- a/model/huggingface_endpoints.py
+++ b/model/huggingface_endpoints.py
@@ -1,0 +1,62 @@
+# -----------------------------------------------------
+# 1) 필수 라이브러리 및 모듈 임포트
+# -----------------------------------------------------
+import os
+from dotenv import load_dotenv                     # .env 파일에서 환경 변수 로드
+from huggingface_hub import login                  # Hugging Face 허브 로그인
+from langchain.prompts import PromptTemplate        # 프롬프트 템플릿 생성기
+from langchain_core.output_parsers import StrOutputParser  # 문자열 출력 파서
+from langchain_huggingface import HuggingFaceEndpoint     # Hugging Face Endpoint 래퍼
+
+# -----------------------------------------------------
+# 2) 환경 변수 (.env) 로드
+# -----------------------------------------------------
+load_dotenv()  # .env 파일의 키=값 쌍을 os.environ에 등록
+
+# -----------------------------------------------------
+# 3) Hugging Face 허브에 비대화형 로그인
+# -----------------------------------------------------
+#   – CLI 대화형 모드 없이 토큰만으로 인증 완료(jupiter Notobook 미사용)
+login(token=os.environ["HUGGINGFACEHUB_API_TOKEN"])
+
+# -----------------------------------------------------
+# 4) 프롬프트 템플릿 정의
+# -----------------------------------------------------
+#   – system, user, assistant 블록으로 구성된 Chat 형식
+template = """<|system|>
+You are a helpful assistant.<|end|>
+<|user|>
+{question}<|end|>
+<|assistant|>"""
+prompt = PromptTemplate.from_template(template)
+# prompt = PromptTemplate(
+#     template=template,
+#     input_variables=["question"],
+# )
+
+# -----------------------------------------------------
+# 5) 사용할 모델 저장소 ID 설정
+# -----------------------------------------------------
+repo_id = "microsoft/Phi-3-mini-4k-instruct"
+
+# -----------------------------------------------------
+# 6) HuggingFaceEndpoint 객체 생성
+# -----------------------------------------------------
+
+llm = HuggingFaceEndpoint(
+    repo_id=repo_id,
+    max_new_tokens=256,  # max_new_tokens: 생성 길이 제한
+    temperature=0.1,     # temperature: 출력 다양성 제어
+    # huggingfacehub_api_token=os.environ["HUGGINGFACEHUB_API_TOKEN"],  # : 위에서 login(token) 안한 경우 엔드포인트에 넣기 가능
+)
+
+# -----------------------------------------------------
+# 7) LangChain 체인 구성
+# -----------------------------------------------------
+chain = prompt | llm | StrOutputParser()
+
+# -----------------------------------------------------
+# 8) 체인 실행 및 결과 출력
+# -----------------------------------------------------
+response = chain.invoke({"question": "what is the capital of South Korea?"})
+print(response)


### PR DESCRIPTION
## Hugging Face Hub란?

- 12만 개 이상의 모델, 2만 개의 데이터셋, 5만 개의 데모 앱(Spaces)을 보유한 플랫폼, 모두 오픈 소스이며 공개적 사용 가능
  - 즉 무료 모델과 데이터셋을 업로드 하고 다운받는 서비스

- LLM 호스팅 서비스 제공
  - 업로드 되어있는 모델을 버튼 클릭만으로 원격으로 호스팅
  - End Point 라는 URL 접속해서 호스팅한 모델 접근해서 사용 가능

### 순서
- 회원가입 & 로그인
- 토큰 발급
- `write` 토큰 발급 받는 것이 좋음

### 참고 모델 리스트
- 허깅페이스 LLM 리더보드: [https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard](https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard)
  - 오픈되어 있는 모델의 리더보드(성능)
    - 가장 좋은 성능을 내는 순으로 올라옴
    - 한국어만 평가한 것이 아닌 다국어 평가 점수

- 모델 리스트: [https://huggingface.co/models?pipeline_tag=text-generation&sort=downloads](https://huggingface.co/models?pipeline_tag=text-generation&sort=downloads)
  - 다양한 모델 리스트
  - 모델의 이름을 잘 봐야함
  - `저작자ID/모델이름` 

- LogicKor 리더보드: [https://lk.instruct.kr/](https://lk.instruct.kr/)
  - 한국어 모델 관련 어떤것이 성능이 좋은지
  - `Qwen/Qwen2-72B-Instruct` Hugging face Id
  - 2024년 10월 17일부로 Archive 상태로 전환됨
    - 사유 : 상위권 모델에 대한 변별력이 거의 없어짐 + 운영적 측면의 관리 어려움 사유

-----

## Huggingface Endpoints 사용

### 사전 세팅

#### huggingface_hub 패키지 설치

```ssh
poetry add huggingface_hub
```

#### `.env` 파일 Token 작성

#### 로그인

```PYTHON
from huggingface_hub import login

login() # Jupyter 사용시 로그인창에서 정보 입력
login(token=os.environ["HUGGINGFACEHUB_API_TOKEN"]) # CLI 대화형 모드 없이 토큰만으로 인증 완료(jupiter Notobook 미사용)
```

----

## Serverless EndPoints
- Inference API는 무료로 사용할 수 있으며 요금은 제한되어 있습니다.
- 프로덕션을 위한 솔루션이 필요한 경우 `Interface Endpoints` 서비스 확인
- Serverless EndPoints나 Inference Endpoint는 허깅페이스에서 무료로 제공하는 추론 서비스 활용

### Inference API 사용 예시
```python
import os  
from langchain_core.output_parsers import StrOutputParser  
from langchain_huggingface import HuggingFaceEndpoint  
  
# 사용할 모델의 저장소 ID를 설정합니다.  
repo_id = "microsoft/Phi-3-mini-4k-instruct"  
  
llm = HuggingFaceEndpoint(  
    repo_id=repo_id,  # 모델 저장소 ID를 지정합니다.  
    max_new_tokens=256,  # 생성할 최대 토큰 길이를 설정합니다.  
    temperature=0.1,  
    huggingfacehub_api_token=os.environ["HUGGINGFACEHUB_API_TOKEN"],  # 허깅페이스 토큰  
)  
  
# LLMChain을 초기화하고 프롬프트와 언어 모델을 전달합니다.  
chain = prompt | llm | StrOutputParser()  
# 질문을 전달하여 LLMChain을 실행하고 결과를 출력합니다.  
response = chain.invoke({"question": "what is the capital of South Korea?"})  
print(response)
```
- `microsoft/Phi-3-mini-4k-instruct` 
	- microsoft 제공
	- 홈페이지 옆에 `inference API` 사용
		- 모든 리포지토리가 다 제공해주진 않음
		- 없는 경우 사용할 수 없음
	
	![[Pasted image 20250611202939.png]]

- 장점 : 비용 무료
	- Inference API 제공하면 가져다 사용할 수 있다.
- 단점 : 성능 아쉽, 할루시네이션 많이 발생할 수 있음
-------
## Hugging Face의 템플릿 이해

#### PromptTemplate 생성 시 모델별 학습한 Template에 맞춰야 한다.
  - Hugging Face Repository에서 특정 모델 상세 사이트 내  `Chat Format` 등 참조한 템플릿 작성하는 것이 좋음

```python
from langchain.prompts import PromptTemplate 

# Hugging Face Repository 설명에서 추출
template = """<|system|> You are a helpful assistant.<|end|> <|user|> {question}<|end|> <|assistant|>""" 

prompt = PromptTemplate.from_template(template)
```

- 모델
  - 데이터 학습엔 template를 가지고 학습
    - 모델마다 양식이 다름
    - 모델이 어떤 양식을 사용했는지 아는것이 좋음
  - 아래쪽 쭉 내리면
    - `Chat Format`
      ![image](https://github.com/user-attachments/assets/c0ddcb99-30c9-4fe9-b576-c7792e4c0013)

- 모델마다 친절하게 양식을 제공해주기도 하지만 제공하지 않기도 함
  - 제공 하지 않으면 양식을 찾아봐야 함

-------
## 전용 엔드포인트(Dedicated Endpoint) - 로컬 모델 원격 호스팅

- 무료 모델 차원에서 API 제공하지 않는 경우 직접 호스팅 필요
- `Inference Endpoints - Dedicated` 
  - 배포 과정 쉬움
  - GPU 없어도 됨
- `Deploy yout first model` > model 선택
  - 야놀자에서 공개한 모델 `eeve-korean-instruct-10.8B-v1.0`
  - Inference API 제공하지 않아 배포시 사용 가능
  - [yanolja/EEVE-Korean-Instruct-10.8B-v1.0](https://huggingface.co/yanolja/EEVE-Korean-Instruct-10.8B-v1.0)

- model 선택

- 이후 서버 선택

- Server 사양 선택
  - `Suggested` 하는것 추천
  - 아마존이 보통 저렴한 편

- `Automatic Scale-to-Zero`
  - 사용량이 적을때 서버 내리기
  - 설정 가능한 속성
    - `Never automatically scale to zero` : 서버 아에 안끄기
    - `After 1 hour with no activity` : 1시간 아무런 액티비티 없으면 끄기 등
- `Endpoint security level`
  - Protected : `TLS/SSL`에 한해 이뤄짐
  - 내가 가진 토큰
  - 내가 발급한 토큰 쉐어해서 팀 내에서 공유
    - Public : 전체
    - Private : 나만

- 모든 설정 완료 후
  - `Endpoiunt URL` 생김
  - 밑에서 테스트 해볼 수도 있으나 URL 가져다가 직접 사용한 예제
  - 프롬프트를 잘 지켜주는것은 동일
    - 제공하는 Hugging Face Repository 상세 페이지 하단에 Prompt 예시 참고해서 넣어주는 것이 좋음

**비용 문제로 실제 배포하진 않음**

### 변경 방법
- 매개변수에 넘길 데이터 `repo_id` -> `url` 변경

```python
# Inference Endpoint URL을 아래에 설정합니다.
hf_endpoint_url = "https://slcalzucia3n7y3g.us-east-1.aws.endpoints.huggingface.cloud"
llm = HuggingFaceEndpoint(
    # 엔드포인트 URL을 설정합니다.
    endpoint_url=hf_endpoint_url,
    max_new_tokens=512,
    temperature=0.01,
)
```

- (필요시) 프롬프트 template 변경
  - 배포한 모델의 학습한 Prompt 형태에 맞춘 형태로 변경해야 함
```python
prompt = ChatPromptTemplate.from_messages(
    [
        (
            "system",
            "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the user's questions.",
        ),
        ("user", "Human: {question}\nAssistant: "),
    ]
)
```

- 상세 예시는 테디 노트 위키독스 참조 
- [06. 허깅페이스 엔드포인트(HuggingFace Endpoints)](https://wikidocs.net/233802)

- Hugging Face를 도저히 뭔지 노트보고는 잘 몰라 강의를 보고 요약한 내용과 섞여있습니다!
