### PR TITLE
feat : 대화 토큰 버퍼 메모리(ConversatinTokenBufferMemory) 완성

### DIFF
--- a/memory/conversation_token_buffer_memory.py
+++ b/memory/conversation_token_buffer_memory.py
@@ -1,0 +1,57 @@
+# API KEY를 환경변수로 관리하기 위한 설정 파일
+from dotenv import load_dotenv
+from langchain.memory import ConversationTokenBufferMemory
+from langchain_openai import ChatOpenAI
+
+# API KEY 정보로드
+load_dotenv()
+
+# LLM 모델 생성
+llm = ChatOpenAI()
+
+# 메모리 설정
+## - 최대 토큰 길이를 150개로 제한
+memory = ConversationTokenBufferMemory(llm=llm, max_token_limit=150, return_messages=True)
+
+# 더미 대화내역 생성
+memory.save_context(
+    inputs={
+        "human": "안녕하세요, 저는 최근에 여러분 회사의 공작 기계를 구매했습니다. 설치 방법을 알려주실 수 있나요?"
+    },
+    outputs={
+        "ai": "안녕하세요! 구매해 주셔서 감사합니다. 해당 기계 모델 번호를 알려주시겠어요?"
+    },
+)
+memory.save_context(
+    inputs={"human": "네, 모델 번호는 XG-200입니다."},
+    outputs={
+        "ai": "감사합니다. XG-200 모델의 설치 안내를 도와드리겠습니다. 먼저, 설치할 장소의 전원 공급 상태를 확인해주세요. 기계는 220V 전원이 필요합니다."
+    },
+)
+memory.save_context(
+    inputs={"human": "전원은 확인했습니다. 다음 단계는 무엇인가요?"},
+    outputs={
+        "ai": "좋습니다. 다음으로, 기계를 평평하고 안정된 바닥에 배치해 주세요. 이후, 제공된 사용자 매뉴얼에 따라 케이블 연결을 진행해 주시기 바랍니다."
+    },
+)
+memory.save_context(
+    inputs={"human": "연결은 어떻게 하나요?"},
+    outputs={
+        "ai": "매뉴얼의 5페이지를 참조해 주세요. 케이블 연결에 관한 상세한 지침이 있습니다. 이 과정에서 어려움이 있으시면 추가적으로 도와드리겠습니다."
+    },
+)
+memory.save_context(
+    inputs={"human": "설치가 완료되면 어떻게 해야 하나요?"},
+    outputs={
+        "ai": "설치가 완료되면, 전원을 켜고 초기 구동 테스트를 진행해 주시기 바랍니다. 테스트 절차는 매뉴얼의 10페이지에 설명되어 있습니다. 만약 기계에 이상이 있거나 추가적인 지원이 필요하시면 언제든지 연락 주시기 바랍니다."
+    },
+)
+memory.save_context(
+    inputs={"human": "감사합니다, 도움이 많이 되었어요!"},
+    outputs={
+        "ai": "언제든지 도와드릴 준비가 되어 있습니다. 추가적인 질문이나 지원이 필요하시면 언제든지 문의해 주세요. 좋은 하루 되세요!"
+    },
+)
+
+# 대화 내용 확인 -> 가장 마지막 대화만 남음 확인됨
+print(memory.load_memory_variables({})["history"])


### PR DESCRIPTION
## ConversationTokenBufferMemory
- 최근 대화 내용을 **버퍼 메모리**에 보관하며, 대화의 **개수**가 아니라 **토큰 길이**를 기준으로 관리합니다.
- 입력과 출력의 토큰 합이 `max_token_limit`을 초과하면, 가장 오래된 대화부터 순차적으로 제거하여 제한 이내로 유지합니다.
- 현재 LangChain에서 deprecated 처리되었고 차후 버전에서 제거될 예정

- `save_context(inputs, outputs)` 호출 시
    - 입력 + 출력 = 하나의 대화 기록으로 버퍼에 추가
    - 전체 대화 기록의 토큰 길이 합을 다시 계산
        
- 만약 총합이 `max_token_limit`(예: 150)을 초과하면
    - 가장 오래된 대화 기록부터 삭제
    - 총합이 150 이내로 내려갈 때까지 반복

- 단 가장 최신 대화 쌍이 `max_token_limit`을 초과하더라도 무조건 남는다.
	- ex) `max_token_limit = 150` 이고 마지막 대화 `Token = 200` 가정
		- 이전 대화 기록 모두 삭제
		- `200 Token` 의 최신 대화 쌍만 버퍼에 남음

