### PR TITLE
06. 대화 요약 메모리(ConversationSummaryMemory)

### DIFF
--- a/memory/conversation_summary_buffer_memory.py
+++ b/memory/conversation_summary_buffer_memory.py
@@ -1,0 +1,54 @@
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+from langchain.memory import ConversationSummaryBufferMemory
+
+
+load_dotenv()
+
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)  # token 계산 4.1-nano 미지원으로 변경
+
+memory = ConversationSummaryBufferMemory(
+    llm = llm,
+    max_token_limit=200,  # 요약의 기준이 되는 토큰 길이 설정
+    return_messages=True,
+)
+
+memory.save_context(
+    inputs={"human" : "유럽 여행 패키지의 가격은 얼마인가요?"},
+    outputs={
+        "ai": "유럽 14박 15일 패키지의 기본 가격은 3,500유로입니다. 이 가격에는 항공료, 호텔 숙박비, 지정된 관광지 입장료가 포함되어 있습니다. 추가 비용은 선택하신 옵션 투어나 개인 경비에 따라 달라집니다."
+    },
+)
+
+# 메모리에 저장된 대화내용 확인
+print(memory.load_memory_variables({})["history"]) # 아직 200토큰이 안되어 요약하지 않고 대화 내용 저장
+
+memory.save_context(
+    inputs={"human": "여행 중에 방문할 주요 관광지는 어디인가요?"},
+    outputs={
+        "ai": "이 여행에서는 파리의 에펠탑, 로마의 콜로세움, 베를린의 브란덴부르크 문, 취리히의 라이네폴 등 유럽의 유명한 관광지들을 방문합니다. 각 도시의 대표적인 명소들을 포괄적으로 경험하실 수 있습니다."
+    },
+)
+memory.save_context(
+    inputs={"human": "여행자 보험은 포함되어 있나요?"},
+    outputs={
+        "ai": "네, 모든 여행자에게 기본 여행자 보험을 제공합니다. 이 보험은 의료비 지원, 긴급 상황 발생 시 지원 등을 포함합니다. 추가적인 보험 보장을 원하시면 상향 조정이 가능합니다."
+    },
+)
+memory.save_context(
+    inputs={
+        "human": "항공편 좌석을 비즈니스 클래스로 업그레이드할 수 있나요? 비용은 어떻게 되나요?"
+    },
+    outputs={
+        "ai": "항공편 좌석을 비즈니스 클래스로 업그레이드하는 것이 가능합니다. 업그레이드 비용은 왕복 기준으로 약 1,200유로 추가됩니다. 비즈니스 클래스에서는 더 넓은 좌석, 우수한 기내식, 그리고 추가 수하물 허용량 등의 혜택을 제공합니다."
+    },
+)
+memory.save_context(
+    inputs={"human": "패키지에 포함된 호텔의 등급은 어떻게 되나요?"},
+    outputs={
+        "ai": "이 패키지에는 4성급 호텔 숙박이 포함되어 있습니다. 각 호텔은 편안함과 편의성을 제공하며, 중심지에 위치해 관광지와의 접근성이 좋습니다. 모든 호텔은 우수한 서비스와 편의 시설을 갖추고 있습니다."
+    },
+)
+
+# 메모리에 저장된 대화내용 확인
+print(memory.load_memory_variables({})["history"])

--- a/memory/conversation_summary_memory.py
+++ b/memory/conversation_summary_memory.py
@@ -1,0 +1,135 @@
+# API KEY를 환경변수로 관리하기 위한 설정 파일
+from dotenv import load_dotenv
+from langchain_core.prompts import PromptTemplate
+from langchain.memory import ConversationSummaryMemory
+from langchain_openai import ChatOpenAI
+
+# API KEY 정보로드
+load_dotenv()
+
+llm = ChatOpenAI(model="gpt-4.1-nano", temperature=0)
+
+memory = ConversationSummaryMemory(llm=llm, return_messages=True)
+
+memory.save_context(
+    inputs={"human": "유럽 여행 패키지의 가격은 얼마인가요?"},
+    outputs={
+        "ai": "유럽 14박 15일 패키지의 기본 가격은 3,500유로입니다. 이 가격에는 항공료, 호텔 숙박비, 지정된 관광지 입장료가 포함되어 있습니다. 추가 비용은 선택하신 옵션 투어나 개인 경비에 따라 달라집니다."
+    },
+)
+memory.save_context(
+    inputs={"human": "여행 중에 방문할 주요 관광지는 어디인가요?"},
+    outputs={
+        "ai": "이 여행에서는 파리의 에펠탑, 로마의 콜로세움, 베를린의 브란덴부르크 문, 취리히의 라이네폴 등 유럽의 유명한 관광지들을 방문합니다. 각 도시의 대표적인 명소들을 포괄적으로 경험하실 수 있습니다."
+    },
+)
+memory.save_context(
+    inputs={"human": "여행자 보험은 포함되어 있나요?"},
+    outputs={
+        "ai": "네, 모든 여행자에게 기본 여행자 보험을 제공합니다. 이 보험은 의료비 지원, 긴급 상황 발생 시 지원 등을 포함합니다. 추가적인 보험 보장을 원하시면 상향 조정이 가능합니다."
+    },
+)
+memory.save_context(
+    inputs={
+        "human": "항공편 좌석을 비즈니스 클래스로 업그레이드할 수 있나요? 비용은 어떻게 되나요?"
+    },
+    outputs={
+        "ai": "항공편 좌석을 비즈니스 클래스로 업그레이드하는 것이 가능합니다. 업그레이드 비용은 왕복 기준으로 약 1,200유로 추가됩니다. 비즈니스 클래스에서는 더 넓은 좌석, 우수한 기내식, 그리고 추가 수하물 허용량 등의 혜택을 제공합니다."
+    },
+)
+memory.save_context(
+    inputs={"human": "패키지에 포함된 호텔의 등급은 어떻게 되나요?"},
+    outputs={
+        "ai": "이 패키지에는 4성급 호텔 숙박이 포함되어 있습니다. 각 호텔은 편안함과 편의성을 제공하며, 중심지에 위치해 관광지와의 접근성이 좋습니다. 모든 호텔은 우수한 서비스와 편의 시설을 갖추고 있습니다."
+    },
+)
+memory.save_context(
+    inputs={"human": "식사 옵션에 대해 더 자세히 알려주실 수 있나요?"},
+    outputs={
+        "ai": "이 여행 패키지는 매일 아침 호텔에서 제공되는 조식을 포함하고 있습니다. 점심과 저녁 식사는 포함되어 있지 않아, 여행자가 자유롭게 현지의 다양한 음식을 경험할 수 있는 기회를 제공합니다. 또한, 각 도시별로 추천 식당 리스트를 제공하여 현지의 맛을 최대한 즐길 수 있도록 도와드립니다."
+    },
+)
+memory.save_context(
+    inputs={"human": "패키지 예약 시 예약금은 얼마인가요? 취소 정책은 어떻게 되나요?"},
+    outputs={
+        "ai": "패키지 예약 시 500유로의 예약금이 필요합니다. 취소 정책은 예약일로부터 30일 전까지는 전액 환불이 가능하며, 이후 취소 시에는 예약금이 환불되지 않습니다. 여행 시작일로부터 14일 전 취소 시 50%의 비용이 청구되며, 그 이후는 전액 비용이 청구됩니다."
+    },
+)
+
+# 저장된 메모리 확인
+print(memory.load_memory_variables({})["history"])
+
+#---------------------------------- 한글 요약 프롬프트 커스터마이징 ----------------------
+
+KOREAN_SUMMARY_TEMPLATE = PromptTemplate.from_template(
+    """
+    당신은 대화를 한국어로 요약을 잘하는 전문가입니다.
+
+    아래 기존 대화 내용 요약 정보와 새로운 대화 내용을 바탕으로 최종 대화 내용을 한글로 간결하게 요약하세요.
+    
+    ## 기존 대화 요약 정보
+    
+    {summary}
+    
+    ## 새로운 대화 내용 정보
+    
+    {new_lines}
+    """
+)
+
+llm_kor = ChatOpenAI(model="gpt-4.1-nano", temperature=0)
+
+
+kor_memory = ConversationSummaryMemory(
+    llm=llm_kor,
+    return_messages=True,
+    prompt=KOREAN_SUMMARY_TEMPLATE
+)
+
+kor_memory.save_context(
+    inputs={"human": "유럽 여행 패키지의 가격은 얼마인가요?"},
+    outputs={
+        "ai": "유럽 14박 15일 패키지의 기본 가격은 3,500유로입니다. 이 가격에는 항공료, 호텔 숙박비, 지정된 관광지 입장료가 포함되어 있습니다. 추가 비용은 선택하신 옵션 투어나 개인 경비에 따라 달라집니다."
+    },
+)
+kor_memory.save_context(
+    inputs={"human": "여행 중에 방문할 주요 관광지는 어디인가요?"},
+    outputs={
+        "ai": "이 여행에서는 파리의 에펠탑, 로마의 콜로세움, 베를린의 브란덴부르크 문, 취리히의 라이네폴 등 유럽의 유명한 관광지들을 방문합니다. 각 도시의 대표적인 명소들을 포괄적으로 경험하실 수 있습니다."
+    },
+)
+kor_memory.save_context(
+    inputs={"human": "여행자 보험은 포함되어 있나요?"},
+    outputs={
+        "ai": "네, 모든 여행자에게 기본 여행자 보험을 제공합니다. 이 보험은 의료비 지원, 긴급 상황 발생 시 지원 등을 포함합니다. 추가적인 보험 보장을 원하시면 상향 조정이 가능합니다."
+    },
+)
+kor_memory.save_context(
+    inputs={
+        "human": "항공편 좌석을 비즈니스 클래스로 업그레이드할 수 있나요? 비용은 어떻게 되나요?"
+    },
+    outputs={
+        "ai": "항공편 좌석을 비즈니스 클래스로 업그레이드하는 것이 가능합니다. 업그레이드 비용은 왕복 기준으로 약 1,200유로 추가됩니다. 비즈니스 클래스에서는 더 넓은 좌석, 우수한 기내식, 그리고 추가 수하물 허용량 등의 혜택을 제공합니다."
+    },
+)
+kor_memory.save_context(
+    inputs={"human": "패키지에 포함된 호텔의 등급은 어떻게 되나요?"},
+    outputs={
+        "ai": "이 패키지에는 4성급 호텔 숙박이 포함되어 있습니다. 각 호텔은 편안함과 편의성을 제공하며, 중심지에 위치해 관광지와의 접근성이 좋습니다. 모든 호텔은 우수한 서비스와 편의 시설을 갖추고 있습니다."
+    },
+)
+kor_memory.save_context(
+    inputs={"human": "식사 옵션에 대해 더 자세히 알려주실 수 있나요?"},
+    outputs={
+        "ai": "이 여행 패키지는 매일 아침 호텔에서 제공되는 조식을 포함하고 있습니다. 점심과 저녁 식사는 포함되어 있지 않아, 여행자가 자유롭게 현지의 다양한 음식을 경험할 수 있는 기회를 제공합니다. 또한, 각 도시별로 추천 식당 리스트를 제공하여 현지의 맛을 최대한 즐길 수 있도록 도와드립니다."
+    },
+)
+kor_memory.save_context(
+    inputs={"human": "패키지 예약 시 예약금은 얼마인가요? 취소 정책은 어떻게 되나요?"},
+    outputs={
+        "ai": "패키지 예약 시 500유로의 예약금이 필요합니다. 취소 정책은 예약일로부터 30일 전까지는 전액 환불이 가능하며, 이후 취소 시에는 예약금이 환불되지 않습니다. 여행 시작일로부터 14일 전 취소 시 50%의 비용이 청구되며, 그 이후는 전액 비용이 청구됩니다."
+    },
+)
+
+# 저장된 메모리 확인
+print(kor_memory.load_memory_variables({})["history"])


### PR DESCRIPTION
## ConversationSummaryMemory

- 시간 경과에 따른 대화 요약 생성
- 대화가 진행되는 동안 대화를 요약하고 현재 요약을 메모리에 저장
- 요약문을 체인이나 프롬프트에 삽입할 수 있어 대화를 전부 보관하지 않고도 맥락 유지 가능
- 특히 **토큰 절약**이 필요한 긴 대화에서 유용
### 동작 방식

- `save_context` 호출 시 
	- 방금 턴의 대화 쌍을 `Human: ... \n AI: ...` 형태의 새 줄로 만듦
	- 이미 갖고 있던 기존 요약문 + 새 줄 LLM을 넣어 새 요약문 생성
	- 그 결과를 내부 버퍼(요약문)에 덮어씌움

- `load_memory_variables` 호출 시
	- 보관중인 요약문 그대로 반환
	- LLM 호출하지 않음

### 기본 프롬프트 예시

```css
You are to progressively summarize the conversation.
Current summary:
{summary}

New lines of conversation:
Human: {last_user_text}
AI: {last_ai_text}

Write a new summary that combines the previous summary and the new lines.

```
- `summary` = 지금까지 누적된 요약문
- `last_user_text`, `last_ai_text` = 직전 턴의 대화
- 프롬프트 1회 → LLM 1회 호출 → 새로운 요약문 생성

### 영어로 응답 받기 싫다.
- 기본 템플릿이 영어로 되어 있기 때문에, 대화가 한글이어도 요약은 영어로 생성될 수 있음
- **해결 방법**: 한국어로 작성한 커스터마이즈 프롬프트를 `ConversationSummaryMemory`의 `prompt` 매개변수로 전달


```python
KOREAN_SUMMARY_TEMPLATE = PromptTemplate.from_template(
    """
    당신은 대화를 한국어로 요약하는 전문가입니다.
    
    ## 기존 요약
    {summary}

    ## 새로운 대화
    Human: {last_user_text}
    AI: {last_ai_text}

    ## 지시사항
    위 내용을 바탕으로 한글로 간결하게 요약하세요.
    """
)

kor_memory = ConversationSummaryMemory(
    llm=llm_kor,
    prompt=KOREAN_SUMMARY_TEMPLATE  # 프롬프트 지정 가능
)

```


## ConversationSummaryBufferMemory

- 긴 대화에서 최근 내용은 원문(버퍼) 그대로, 이전 내용은 요약으로 남기고 싶을 때 사용
- 프롬프트에 실을 토큰을 아끼면서도 맥락은 유지할 수 있음
- `ConversationBufferMemory` + `ConversationSummaryMemory` 의 하이브리드


### 동작 방식
- 매 `save_context` 시, 해당 턴의 Human/AI 대화 쌍이 버퍼에 그대로 추가됨
- **요약 + 버퍼의 토큰 길이를 계산**해 `max_token_limit`을 넘으면:
    - **오래된 버퍼 메시지부터** 꺼내 요약에 합침(LLM 호출)
    - 한도 이하가 될 때까지 반복(필요 시 여러 번 호출될 수 있음)
- **가장 최근 대화 몇 턴은 원문 유지**(최신 맥락을 정확히 이어가기 위함)

### 토큰 기준으로 움직인다.
- 최근 N턴 같은 턴 개수 기준이 아닌 토큰 길이 기준 정리
- `max_token_limit` 안에 요약 + 최근 원문이 들어오도록 자동 압축

```css
[ Summary(요약문) ]  +  [ Buffer(최근 원문 메시지들) ] <=  max_token_limit 유지
```

### 요약은 LLM을 몇 번 부르나?
- `save_context` 마다 **무조건** 요약하지 않음
	- 길이가 한도를 넘지 않으면 **LLM 호출 없음**
- 한도를 넘으면 **넘지 않을 때까지** 오래된 버퍼를 조금씩 요약에 합침
	- 1번 이상 LLM 호출될 수 있음

### 한글 응답을 기대한다면?
- ConversationSummaryMemory와 마찬가지로 프롬프트 커스터마이징 하여 매개변수로 설정할 수 있다.

```python
KOREAN_SUMMARY_PROMPT = PromptTemplate.from_template("""
당신은 대화를 한국어로 간결하게 요약합니다.

[기존 요약]
{summary}

[새로 합칠 대화]
{new_lines}

위 내용을 바탕으로 핵심만 자연스럽게 한글로 요약하세요.
""")

llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)  # 토큰 계산 지원되는 모델 권장

memory = ConversationSummaryBufferMemory(
    llm=llm,
    prompt=KOREAN_SUMMARY_PROMPT,
    max_token_limit=200,      # 요약 + 버퍼의 목표 길이
    return_messages=True,
)

```
- `gpt-4.1-nano`는 LangChain에서 토큰 계산기가 연결 안되어있어 `max_token_limit` 사용 시 `NotImplementedError` 발생
	- `gpt-4o-mini` 와 같은 지원 모델 사용
	- `tiktoken`으로 직접 토큰 카운터 패치

## 예제로 보는 흐름 (토큰 한도를 100이라 가정)

1. 턴1 저장 → `요약=비어있음`, `버퍼=[턴1 원문]` → 한도 이하 → **요약 안 함**
2. 턴2 저장 → `버퍼=[턴1, 턴2]` → 여전히 한도 이하 → **요약 안 함**
3. 턴3 저장 → `버퍼=[턴1, 턴2, 턴3]` → 한도 **초과**
    -  오래된 메시지(턴1)를 꺼내 `요약(빈값)`과 합쳐 **요약 생성**(LLM 1회)
    - `요약=턴1 요약`, `버퍼=[턴2, 턴3]`
	- 여전히 초과하면 턴2도 요약으로 이동 → `요약=턴1+턴2 요약`, `버퍼=[턴3]`
	- **가능하면 턴3(가장 최근)은 원문으로 유지**
	    - 초과가 약간 남더라도 최신 턴은 보존하려는 경향이 있음
	    - 만약 계속 초과한다면 `max_token_limit`을 더 크게 잡는 게 실무적으로 안전
    